### PR TITLE
Develop

### DIFF
--- a/lib/rpg_game.dart
+++ b/lib/rpg_game.dart
@@ -4,7 +4,6 @@ import 'package:bonfire/joystick/joystick_controller.dart';
 import 'package:bonfire/map/map_game.dart';
 import 'package:bonfire/player/player.dart';
 import 'package:bonfire/util/base_game_point_detector.dart';
-import 'package:bonfire/util/camera.dart';
 import 'package:bonfire/util/game_component.dart';
 import 'package:bonfire/util/game_controller.dart';
 import 'package:bonfire/util/game_interface/game_interface.dart';
@@ -14,7 +13,6 @@ import 'package:bonfire/util/lighting/lighting_config.dart';
 import 'package:bonfire/util/lighting/with_lighting.dart';
 import 'package:bonfire/util/map_explorer.dart';
 import 'package:bonfire/util/value_generator.dart';
-import 'package:flame/components/component.dart';
 import 'package:flame/keyboard.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -28,7 +26,6 @@ class RPGGame extends BaseGamePointerDetector with KeyboardEvents {
   final MapGame map;
   final JoystickController joystickController;
   final GameComponent background;
-  final Camera gameCamera = Camera();
   final bool constructionMode;
   final bool showCollisionArea;
   final GameController gameController;
@@ -81,19 +78,6 @@ class RPGGame extends BaseGamePointerDetector with KeyboardEvents {
   void update(double t) {
     _interval.update(t);
     super.update(t);
-  }
-
-  @override
-  void renderComponent(Canvas canvas, Component comp) {
-    if (!comp.loaded()) {
-      return;
-    }
-    canvas.save();
-    if (!comp.isHud()) {
-      canvas.translate(-gameCamera.position.x, -gameCamera.position.y);
-    }
-    comp.render(canvas);
-    canvas.restore();
   }
 
   void addEnemy(Enemy enemy) {

--- a/lib/util/base_game_point_detector.dart
+++ b/lib/util/base_game_point_detector.dart
@@ -9,9 +9,11 @@ import 'package:flame/game/game.dart';
 import 'package:flutter/widgets.dart';
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
+import 'package:bonfire/util/camera.dart';
 
 abstract class BaseGamePointerDetector extends Game with PointerDetector {
   bool _isPause = false;
+  final Camera gameCamera = Camera();
 
   /// The list of components to be updated and rendered by the base game.
   OrderedSet<Component> components =
@@ -111,7 +113,10 @@ abstract class BaseGamePointerDetector extends Game with PointerDetector {
   @override
   void render(Canvas canvas) {
     canvas.save();
+
+    canvas.translate(-gameCamera.position.x, -gameCamera.position.y);
     components.forEach((comp) => renderComponent(canvas, comp));
+
     canvas.restore();
   }
 
@@ -119,13 +124,18 @@ abstract class BaseGamePointerDetector extends Game with PointerDetector {
   ///
   /// It translates the camera unless hud, call the render method and restore the canvas.
   /// This makes sure the canvas is not messed up by one component and all components render independently.
-  void renderComponent(Canvas canvas, Component c) {
-    if (!c.loaded()) {
+  void renderComponent(Canvas canvas, Component comp) {
+    if (!comp.loaded()) {
       return;
     }
-    c.render(canvas);
-    canvas.restore();
     canvas.save();
+  
+    if (comp.isHud()) {
+      canvas.translate(gameCamera.position.x, gameCamera.position.y);
+    }
+    comp.render(canvas);
+
+    canvas.restore();
   }
 
   /// This implementation of update updates every component in the list.
@@ -179,7 +189,7 @@ abstract class BaseGamePointerDetector extends Game with PointerDetector {
   /// This is a hook that comes from the RenderBox to allow recording of render times and statistics.
   @override
   void recordDt(double dt) {
-    if (debugMode()) {
+    if (recordFps()) {
       _dts.add(dt);
     }
   }

--- a/lib/util/base_game_point_detector.dart
+++ b/lib/util/base_game_point_detector.dart
@@ -127,6 +127,8 @@ abstract class BaseGamePointerDetector extends Game with PointerDetector {
   void renderComponent(Canvas canvas, Component comp) {
     if (!comp.loaded()) {
       return;
+    } else if (comp is GameComponent) {
+      if (!comp.isHud() && !gameCamera.isComponentOnCamera(comp)) return;
     }
     canvas.save();
   


### PR DESCRIPTION
Well... when having multiple (and by multiple i mean 5k+) game decorations, there were a huge performance loss. Investigating i found that one of the main reasons was making the camera translate for every component, so i inverted the logic so that it makes the transformation back when it's a HUD component (since there are way less HUD components than normal ones). 