### PR TITLE
Stop engine where open dialog

### DIFF
--- a/example/lib/player/knight.dart
+++ b/example/lib/player/knight.dart
@@ -228,6 +228,7 @@ class Knight extends SimplePlayer with Lighting, ObjectCollision {
       first,
       zoom: 2,
       finish: () {
+        gameRef.pauseEngine();
         TalkDialog.show(
           gameRef.context,
           [
@@ -251,6 +252,7 @@ class Knight extends SimplePlayer with Lighting, ObjectCollision {
           ],
           finish: () {
             gameRef.camera.moveToPlayerAnimated();
+            gameRef.resumeEngine();
           },
           logicalKeyboardKeyToNext: LogicalKeyboardKey.space,
         );


### PR DESCRIPTION
Previously the enemy attacking even with open dialog. Fix this problem stopping the engine until the dialog is over.

