### PR TITLE
Refactor TalkDialog core to allow RichText animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Next
+- [BREAKING CHANGE] Refactor `TalkDialog` core to allow RichText animations:
+  Now every `Say` requires a `text` param which takes a `List<TextSpan>` instead of a String.
+- Add param `speed` to `TalkDialog`.
+
 # 1.4.4
 - add param `tileSizeToUpdate` to configure interval of the update map.
 

--- a/example/lib/player/knight.dart
+++ b/example/lib/player/knight.dart
@@ -274,7 +274,18 @@ class Knight extends SimplePlayer with Lighting, ObjectCollision, MouseGesture {
           gameRef.context,
           [
             Say(
-              "Look at this! It seems that I'm not alone here ...",
+              text: [
+                TextSpan(
+                  text: "Look at this! It seems that",
+                ),
+                TextSpan(
+                  text: ' I\'m not alone ',
+                  style: TextStyle(color: Colors.red),
+                ),
+                TextSpan(
+                  text: "here...",
+                ),
+              ],
               person: Container(
                 width: 100,
                 height: 100,
@@ -292,7 +303,7 @@ class Knight extends SimplePlayer with Lighting, ObjectCollision, MouseGesture {
             ),
           ],
           finish: () {
-            print('finish');
+            print('finish talk');
             gameRef.camera.moveToPlayerAnimated();
           },
           logicalKeyboardKeyToNext: LogicalKeyboardKey.space,

--- a/example/lib/player/knight.dart
+++ b/example/lib/player/knight.dart
@@ -276,14 +276,14 @@ class Knight extends SimplePlayer with Lighting, ObjectCollision, MouseGesture {
             Say(
               text: [
                 TextSpan(
-                  text: "Look at this! It seems that",
+                  text: 'Look at this! It seems that',
                 ),
                 TextSpan(
                   text: ' I\'m not alone ',
                   style: TextStyle(color: Colors.red),
                 ),
                 TextSpan(
-                  text: "here...",
+                  text: 'here...',
                 ),
               ],
               person: Container(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.3"
+    version: "1.4.4"
   boolean_selector:
     dependency: transitive
     description:

--- a/lib/util/talk/say.dart
+++ b/lib/util/talk/say.dart
@@ -3,10 +3,18 @@ import 'package:flutter/material.dart';
 enum PersonSayDirection { LEFT, RIGHT }
 
 class Say {
-  final String text;
+  /// List of TextSpans to be shown in a TalkDialog.
+  /// Example:
+  /// ```dart
+  /// [
+  ///   TextSpan(text: 'New'),
+  ///   TextSpan(text: ' item ', style: TextStyle(color: Colors.red)),
+  ///   TextSpan(text: 'unlocked!'),
+  /// ]
+  /// ```
+  final List<TextSpan> text;
   final Widget? person;
   final PersonSayDirection personSayDirection;
-  final TextStyle? textStyle;
   final BoxDecoration? boxDecoration;
   final EdgeInsetsGeometry? padding;
   final EdgeInsetsGeometry? margin;
@@ -14,10 +22,14 @@ class Say {
   final Widget? header;
   final Widget? bottom;
 
-  Say(
-    this.text, {
+  /// How long each character takes to be shown, in milliseconds.
+  /// Defaults to 50.
+  final int? speed;
+
+  /// Create a text animation to be shown inside `TalkDialog.show`
+  Say({
+    required this.text,
     this.personSayDirection = PersonSayDirection.LEFT,
-    this.textStyle,
     this.boxDecoration,
     this.padding,
     this.margin,
@@ -25,5 +37,6 @@ class Say {
     this.background,
     this.header,
     this.bottom,
+    this.speed,
   });
 }

--- a/lib/util/talk/talk_dialog.dart
+++ b/lib/util/talk/talk_dialog.dart
@@ -203,9 +203,8 @@ class _TalkDialogState extends State<TalkDialog> {
     // Clean the stream to prevent textStyle from changing before the text
     _textShowController.add([TextSpan()]);
 
-    await Future.forEach(currentSay.text, (span) async {
-      TextSpan _currentSpan = span as TextSpan;
-      for (int i = 0; i < (_currentSpan.text?.length ?? 0); i++) {
+    await Future.forEach<TextSpan>(currentSay.text, (span) async {
+      for (int i = 0; i < (span.text?.length ?? 0); i++) {
         if (finishedCurrentSay) {
           _textShowController.add([...currentSay.text]);
           break;
@@ -214,8 +213,8 @@ class _TalkDialogState extends State<TalkDialog> {
         _textShowController.add([
           ...currentSay.text.sublist(0, currentSay.text.indexOf(span)),
           TextSpan(
-            text: _currentSpan.text!.substring(0, i + 1),
-            style: _currentSpan.style,
+            text: span.text!.substring(0, i + 1),
+            style: span.style,
           )
         ]);
       }

--- a/lib/util/talk/talk_dialog.dart
+++ b/lib/util/talk/talk_dialog.dart
@@ -54,7 +54,6 @@ class TalkDialog extends StatefulWidget {
 
 class _TalkDialogState extends State<TalkDialog> {
   final FocusNode _focusNode = FocusNode();
-  Timer? timer;
   late Say currentSay;
   int currentIndexTalk = 0;
   bool finishedCurrentSay = false;
@@ -76,7 +75,6 @@ class _TalkDialogState extends State<TalkDialog> {
   void dispose() {
     _textShowController.close();
     _focusNode.dispose();
-    timer?.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
Hey!

This PR introduces the possibility to use `TextSpan` in `TalkDialog`, being useful to give a highlight in certain words.
It is a **breaking change** because I think it is better to ask directly for the `List<TextSpan>` instead of multiple strings and textStyles.

It also adds the  `speed` param to control how long it takes to show each character.

Let me know what you think.
As always, thank you @RafaelBarbosatec !

Preview:

![ew7ZhaRLLd](https://user-images.githubusercontent.com/36611739/128093418-70d75325-7f01-41af-9d3f-4e5c625c112b.gif)

