### PR TITLE
improve player joystick movement

### DIFF
--- a/example/lib/player/knight.dart
+++ b/example/lib/player/knight.dart
@@ -42,6 +42,11 @@ class Knight extends SimplePlayer with Lighting, ObjectCollision, MouseGesture {
           life: 200,
           speed: DungeonMap.tileSize * 3,
         ) {
+    // for the default 8 way movement
+    dPadAngles = true;
+    // for full 360 degree movement
+    // dPadAngles = false;
+
     setupLighting(
       LightingConfig(
         radius: width * 1.5,

--- a/lib/player/player.dart
+++ b/lib/player/player.dart
@@ -34,6 +34,24 @@ class Player extends GameComponent
   }
 
   @override
+  void joystickChangeDirectional(JoystickDirectionalEvent event) {
+    var newAngle = event.radAngle;
+    if (dPadAngles || newAngle == 0.0) {
+      newAngle = event.directionalRadAngle;
+    }
+    if (event.directional != JoystickMoveDirectional.IDLE &&
+        !isDead &&
+        newAngle != 0.0) {
+      movementRadAngle = newAngle;
+    }
+    super.joystickChangeDirectional(JoystickDirectionalEvent(
+      directional: event.directional,
+      intensity: event.intensity,
+      radAngle: newAngle,
+    ));
+  }
+
+  @override
   void joystickAction(JoystickActionEvent event) {}
 
   @override

--- a/lib/player/rotation_player.dart
+++ b/lib/player/rotation_player.dart
@@ -9,7 +9,6 @@ class RotationPlayer extends Player {
   SpriteAnimation? animIdle;
   SpriteAnimation? animRun;
   double? currentRadAngle;
-  bool _move = false;
   SpriteAnimation? animation;
   final _loader = AssetsLoader();
 
@@ -35,24 +34,17 @@ class RotationPlayer extends Player {
 
   @override
   void joystickChangeDirectional(JoystickDirectionalEvent event) {
-    if (event.directional != JoystickMoveDirectional.IDLE &&
-        !isDead &&
-        event.radAngle != 0.0) {
-      currentRadAngle = event.radAngle;
-      _move = true;
+    super.joystickChangeDirectional(event);
+    if (event.directional != JoystickMoveDirectional.IDLE && !isDead) {
+      currentRadAngle = movementRadAngle;
       this.animation = animRun;
     } else {
-      _move = false;
       this.animation = animIdle;
     }
-    super.joystickChangeDirectional(event);
   }
 
   @override
   void update(double dt) {
-    if (_move && !isDead && currentRadAngle != null) {
-      moveFromAngle(speed, currentRadAngle!);
-    }
     animation?.update(dt);
     super.update(dt);
   }

--- a/lib/util/extensions/extensions.dart
+++ b/lib/util/extensions/extensions.dart
@@ -10,6 +10,7 @@ export 'enemy/enemy_extensions.dart';
 export 'enemy/enemy_extensions.dart';
 export 'enemy/rotation_enemy_extensions.dart';
 export 'game_component_extensions.dart';
+export 'joystick_extensions.dart';
 export 'movement_extensions.dart';
 export 'player/player_extensions.dart';
 export 'player/rotation_player_extensions.dart';

--- a/lib/util/extensions/joystick_extensions.dart
+++ b/lib/util/extensions/joystick_extensions.dart
@@ -1,0 +1,30 @@
+import 'dart:math';
+import 'package:bonfire/joystick/joystick_controller.dart';
+
+extension JoystickDirectionalEventExtention on JoystickDirectionalEvent {
+  double get directionalRadAngle {
+    switch (directional) {
+      case JoystickMoveDirectional.MOVE_LEFT:
+        return 180 / (180 / pi);
+      case JoystickMoveDirectional.MOVE_RIGHT:
+        // we can't use 0 here because then no movement happens
+        // we're just going as close to 0.0 without being exactly 0.0
+        // if you have a better idea. Please be my guest
+        return 0.0000001 / (180 / pi);
+      case JoystickMoveDirectional.MOVE_UP:
+        return -90 / (180 / pi);
+      case JoystickMoveDirectional.MOVE_DOWN:
+        return 90 / (180 / pi);
+      case JoystickMoveDirectional.MOVE_UP_LEFT:
+        return -135 / (180 / pi);
+      case JoystickMoveDirectional.MOVE_UP_RIGHT:
+        return -45 / (180 / pi);
+      case JoystickMoveDirectional.MOVE_DOWN_LEFT:
+        return 135 / (180 / pi);
+      case JoystickMoveDirectional.MOVE_DOWN_RIGHT:
+        return 45 / (180 / pi);
+      default:
+        return 0;
+    }
+  }
+}

--- a/lib/util/mixins/movement_by_joystick.dart
+++ b/lib/util/mixins/movement_by_joystick.dart
@@ -4,50 +4,75 @@ import 'package:bonfire/util/mixins/movement.dart';
 /// Mixin responsible for adding movements through joystick events
 mixin MovementByJoystick on Movement {
   static const REDUCTION_SPEED_DIAGONAL = 0.7;
+
+  /// flag to set if you only want the 8 directions movement. Set to false to have full 360 movement
+  bool dPadAngles = true;
+
+  /// the angle the player should move in 360 mode
+  double movementRadAngle = 0;
+
   @override
   void update(double dt) {
     if (this is JoystickListener) {
       bool joystickContainThisComponent = gameRef.joystickController
               ?.containObserver(this as JoystickListener) ??
           false;
-      if (innerCurrentDirectional != null && joystickContainThisComponent) {
-        final diagonalSpeed = this.speed * REDUCTION_SPEED_DIAGONAL;
-
-        switch (innerCurrentDirectional!) {
-          case JoystickMoveDirectional.MOVE_UP:
-            moveUp(speed);
-            break;
-          case JoystickMoveDirectional.MOVE_UP_LEFT:
-            moveUpLeft(diagonalSpeed, diagonalSpeed);
-            break;
-          case JoystickMoveDirectional.MOVE_UP_RIGHT:
-            moveUpRight(diagonalSpeed, diagonalSpeed);
-            break;
-          case JoystickMoveDirectional.MOVE_RIGHT:
-            moveRight(speed);
-            break;
-          case JoystickMoveDirectional.MOVE_DOWN:
-            moveDown(speed);
-            break;
-          case JoystickMoveDirectional.MOVE_DOWN_RIGHT:
-            moveDownRight(diagonalSpeed, diagonalSpeed);
-            break;
-          case JoystickMoveDirectional.MOVE_DOWN_LEFT:
-            moveDownLeft(diagonalSpeed, diagonalSpeed);
-            break;
-          case JoystickMoveDirectional.MOVE_LEFT:
-            moveLeft(speed);
-            break;
-          case JoystickMoveDirectional.IDLE:
-            if (!isIdle) {
-              idle();
-            }
-            break;
+      if (dPadAngles) {
+        if (innerCurrentDirectional != null && joystickContainThisComponent) {
+          final diagonalSpeed = this.speed * REDUCTION_SPEED_DIAGONAL;
+          _moveDirectional(innerCurrentDirectional!, speed, diagonalSpeed);
+        }
+      } else {
+        if (innerCurrentDirectional != null && joystickContainThisComponent) {
+          if (innerCurrentDirectional != JoystickMoveDirectional.IDLE) {
+            moveFromAngle(speed, movementRadAngle);
+          }
+          // movement was done on the above line, this is only for the animation
+          // which is why we use zero speed as we don't want to translate position twice
+          _moveDirectional(innerCurrentDirectional!, 0, 0);
         }
       }
     }
 
     super.update(dt);
+  }
+
+  void _moveDirectional(
+    JoystickMoveDirectional direction,
+    double speed,
+    double diagonalSpeed,
+  ) {
+    switch (direction) {
+      case JoystickMoveDirectional.MOVE_UP:
+        moveUp(speed);
+        break;
+      case JoystickMoveDirectional.MOVE_UP_LEFT:
+        moveUpLeft(diagonalSpeed, diagonalSpeed);
+        break;
+      case JoystickMoveDirectional.MOVE_UP_RIGHT:
+        moveUpRight(diagonalSpeed, diagonalSpeed);
+        break;
+      case JoystickMoveDirectional.MOVE_RIGHT:
+        moveRight(speed);
+        break;
+      case JoystickMoveDirectional.MOVE_DOWN:
+        moveDown(speed);
+        break;
+      case JoystickMoveDirectional.MOVE_DOWN_RIGHT:
+        moveDownRight(diagonalSpeed, diagonalSpeed);
+        break;
+      case JoystickMoveDirectional.MOVE_DOWN_LEFT:
+        moveDownLeft(diagonalSpeed, diagonalSpeed);
+        break;
+      case JoystickMoveDirectional.MOVE_LEFT:
+        moveLeft(speed);
+        break;
+      case JoystickMoveDirectional.IDLE:
+        if (!isIdle) {
+          idle();
+        }
+        break;
+    }
   }
 
   /// get currentDirectional from `JoystickListener`


### PR DESCRIPTION
**Firstly**
It started by trying to fix `RotationPlayer` as it was translating it's position twice in the `update` method on `moveFromAngle` and `super.update` which updated position again in `MovementByJoystick` mixin.
So by removing the movement from `RotationPlayer` and moving it to `MovementByJoystick` I was able to make it update the position only once.
**Secondly**
Now both `RotationPlayer` and `SimplePlayer` (and any `Player` for that matter) should be able to move in either 360 degree mode or stay in the default locked 8-way mode. This will work on PC keyboard with directional arrows or with on screen joystick.

joystick_extensions.dart line 13 is not great, but I'm not sure how to better handle this