### PR TITLE
ignore touch events if flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# next
+- option to disable touch input on `Joystick` for desktop only controls
 # 1.9.4
 - Small improvements in map loading.
 - Adds `angle` param in `GameComponent` to rotate component render.

--- a/lib/joystick/joystick.dart
+++ b/lib/joystick/joystick.dart
@@ -45,12 +45,14 @@ class KeyboardConfig {
 class Joystick extends JoystickController {
   final List<JoystickAction>? actions;
   final JoystickDirectional? directional;
+  final bool disableTouch;
 
   List<LogicalKeyboardKey> _currentKeyboardKeys = [];
 
   Joystick({
     this.actions,
     this.directional,
+    this.disableTouch = false,
     KeyboardConfig? keyboardConfig,
   }) {
     if (keyboardConfig != null) {
@@ -76,6 +78,7 @@ class Joystick extends JoystickController {
   }
 
   void render(Canvas canvas) {
+    if (disableTouch) return;
     super.render(canvas);
     directional?.render(canvas);
     actions?.forEach((action) => action.render(canvas));
@@ -90,12 +93,14 @@ class Joystick extends JoystickController {
 
   @override
   void handlerPointerCancel(PointerCancelEvent event) {
+    if (disableTouch) return;
     actions?.forEach((action) => action.actionUp(event.pointer));
     directional?.directionalUp(event.pointer);
   }
 
   @override
   void handlerPointerDown(PointerDownEvent event) {
+    if (disableTouch) return;
     directional?.directionalDown(event.pointer, event.localPosition);
     actions?.forEach((action) {
       action.actionDown(event.pointer, event.localPosition);
@@ -104,6 +109,7 @@ class Joystick extends JoystickController {
 
   @override
   void handlerPointerMove(PointerMoveEvent event) {
+    if (disableTouch) return;
     actions?.forEach((action) {
       action.actionMove(event.pointer, event.localPosition);
     });
@@ -112,6 +118,7 @@ class Joystick extends JoystickController {
 
   @override
   void handlerPointerUp(PointerUpEvent event) {
+    if (disableTouch) return;
     actions?.forEach((action) => action.actionUp(event.pointer));
     directional?.directionalUp(event.pointer);
   }


### PR DESCRIPTION
# Description

*When targeting desktop or web platforms where touch controls are not applicable. This allows us to disable touch controls and not render the joystick. However keyboard input is still there.*

## Checklist

- [x] I open this PR to `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.