### PR TITLE
Improvements in Joystick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [next]
 - Fix bug "getting stuck" in `MoveToPositionAlongThePath`
+- [BREAKING CHANGE] Change param `logicalKeyboardKeyToNext` in `TalkDialog` to `logicalKeyboardKeysToNext`, now multiple keys are accepted to advance in the dialogue
+- Add option `wasdAndArrows` to `KeyboardDirectionalType` allowing both arrows and wasd keys to control the joystick
 
 # 1.9.5
 - Update params name of `simpleAttackMelee` in Enemy.

--- a/example/lib/shared/player/knight.dart
+++ b/example/lib/shared/player/knight.dart
@@ -313,7 +313,10 @@ class Knight extends SimplePlayer with Lighting, ObjectCollision, MouseGesture {
             print('finish talk');
             gameRef.camera.moveToPlayerAnimated();
           },
-          logicalKeyboardKeyToNext: LogicalKeyboardKey.space,
+          logicalKeyboardKeysToNext: [
+            LogicalKeyboardKey.space,
+            LogicalKeyboardKey.enter
+          ],
         );
       },
     );

--- a/example/lib/tiled_map/game_tiled_map.dart
+++ b/example/lib/tiled_map/game_tiled_map.dart
@@ -28,6 +28,7 @@ class GameTiledMap extends StatelessWidget {
         return BonfireTiledWidget(
           joystick: Joystick(
             keyboardConfig: KeyboardConfig(
+              keyboardDirectionalType: KeyboardDirectionalType.wasdAndArrows,
               acceptedKeys: [
                 LogicalKeyboardKey.space,
               ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.4"
+    version: "1.9.5"
   boolean_selector:
     dependency: transitive
     description:

--- a/lib/joystick/joystick.dart
+++ b/lib/joystick/joystick.dart
@@ -6,13 +6,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-enum KeyboardDirectionalType { arrows, wasd }
+enum KeyboardDirectionalType { arrows, wasd, wasdAndArrows }
 
 class KeyboardConfig {
   /// Use to enable ou disable keyboard events
   final bool enable;
 
-  /// Type of the directional (arrows or wasd)
+  /// Type of the directional (arrows, wasd or wasdAndArrow)
   final KeyboardDirectionalType keyboardDirectionalType;
 
   /// You can pass specific Keys accepted. If null accept all keys
@@ -36,6 +36,16 @@ class KeyboardConfig {
           acceptedKeys?.add(LogicalKeyboardKey.keyS);
           acceptedKeys?.add(LogicalKeyboardKey.keyA);
           acceptedKeys?.add(LogicalKeyboardKey.keyD);
+          break;
+        case KeyboardDirectionalType.wasdAndArrows:
+          acceptedKeys?.add(LogicalKeyboardKey.keyW);
+          acceptedKeys?.add(LogicalKeyboardKey.keyS);
+          acceptedKeys?.add(LogicalKeyboardKey.keyA);
+          acceptedKeys?.add(LogicalKeyboardKey.keyD);
+          acceptedKeys?.add(LogicalKeyboardKey.arrowLeft);
+          acceptedKeys?.add(LogicalKeyboardKey.arrowRight);
+          acceptedKeys?.add(LogicalKeyboardKey.arrowDown);
+          acceptedKeys?.add(LogicalKeyboardKey.arrowUp);
           break;
       }
     }
@@ -186,11 +196,21 @@ class Joystick extends JoystickController {
           event.logicalKey == LogicalKeyboardKey.arrowUp ||
           event.logicalKey == LogicalKeyboardKey.arrowLeft ||
           event.logicalKey == LogicalKeyboardKey.arrowDown;
-    } else {
+    } else if (keyboardConfig.keyboardDirectionalType ==
+        KeyboardDirectionalType.wasd) {
       return event.logicalKey == LogicalKeyboardKey.keyA ||
           event.logicalKey == LogicalKeyboardKey.keyW ||
           event.logicalKey == LogicalKeyboardKey.keyD ||
           event.logicalKey == LogicalKeyboardKey.keyS;
+    } else {
+      return event.logicalKey == LogicalKeyboardKey.keyA ||
+          event.logicalKey == LogicalKeyboardKey.keyW ||
+          event.logicalKey == LogicalKeyboardKey.keyD ||
+          event.logicalKey == LogicalKeyboardKey.keyS ||
+          event.logicalKey == LogicalKeyboardKey.arrowRight ||
+          event.logicalKey == LogicalKeyboardKey.arrowUp ||
+          event.logicalKey == LogicalKeyboardKey.arrowLeft ||
+          event.logicalKey == LogicalKeyboardKey.arrowDown;
     }
   }
 
@@ -202,6 +222,8 @@ class Joystick extends JoystickController {
       case KeyboardDirectionalType.wasd:
         _oneDirectionWASD(key);
         break;
+      case KeyboardDirectionalType.wasdAndArrows:
+        _oneDirectionWASDAndArrows(key);
     }
   }
 
@@ -273,6 +295,41 @@ class Joystick extends JoystickController {
     }
   }
 
+  void _oneDirectionWASDAndArrows(LogicalKeyboardKey key) {
+    if (key == LogicalKeyboardKey.keyD ||
+        key == LogicalKeyboardKey.arrowRight) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_RIGHT,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+
+    if (key == LogicalKeyboardKey.keyW || key == LogicalKeyboardKey.arrowUp) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_UP,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+
+    if (key == LogicalKeyboardKey.keyA || key == LogicalKeyboardKey.arrowLeft) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_LEFT,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+
+    if (key == LogicalKeyboardKey.keyS || key == LogicalKeyboardKey.arrowDown) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_DOWN,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+  }
+
   void _sendTwoDirection(LogicalKeyboardKey key1, LogicalKeyboardKey key2) {
     switch (keyboardConfig.keyboardDirectionalType) {
       case KeyboardDirectionalType.arrows:
@@ -280,6 +337,9 @@ class Joystick extends JoystickController {
         break;
       case KeyboardDirectionalType.wasd:
         _twoDirectionsWASD(key1, key2);
+        break;
+      case KeyboardDirectionalType.wasdAndArrows:
+        _twoDirectionsWASDAndArrows(key1, key2);
         break;
     }
   }
@@ -360,6 +420,69 @@ class Joystick extends JoystickController {
             key2 == LogicalKeyboardKey.arrowUp ||
         key2 == LogicalKeyboardKey.arrowRight &&
             key1 == LogicalKeyboardKey.arrowUp) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_UP_RIGHT,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+  }
+
+  void _twoDirectionsWASDAndArrows(
+      LogicalKeyboardKey key1, LogicalKeyboardKey key2) {
+    if ((key1 == LogicalKeyboardKey.arrowRight ||
+                key1 == LogicalKeyboardKey.keyD) &&
+            (key2 == LogicalKeyboardKey.arrowDown ||
+                key2 == LogicalKeyboardKey.keyS) ||
+        (key2 == LogicalKeyboardKey.arrowRight ||
+                key2 == LogicalKeyboardKey.keyD) &&
+            (key1 == LogicalKeyboardKey.arrowDown ||
+                key1 == LogicalKeyboardKey.keyS)) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_DOWN_RIGHT,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+
+    if ((key1 == LogicalKeyboardKey.arrowLeft ||
+                key1 == LogicalKeyboardKey.keyA) &&
+            (key2 == LogicalKeyboardKey.arrowDown ||
+                key2 == LogicalKeyboardKey.keyS) ||
+        (key2 == LogicalKeyboardKey.arrowLeft ||
+                key2 == LogicalKeyboardKey.keyA) &&
+            (key1 == LogicalKeyboardKey.arrowDown ||
+                key1 == LogicalKeyboardKey.keyS)) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_DOWN_LEFT,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+
+    if ((key1 == LogicalKeyboardKey.arrowLeft ||
+                key1 == LogicalKeyboardKey.keyA) &&
+            (key2 == LogicalKeyboardKey.arrowUp ||
+                key2 == LogicalKeyboardKey.keyW) ||
+        (key2 == LogicalKeyboardKey.arrowLeft ||
+                key2 == LogicalKeyboardKey.keyA) &&
+            (key1 == LogicalKeyboardKey.arrowUp ||
+                key1 == LogicalKeyboardKey.keyW)) {
+      joystickChangeDirectional(JoystickDirectionalEvent(
+        directional: JoystickMoveDirectional.MOVE_UP_LEFT,
+        intensity: 1.0,
+        radAngle: 0.0,
+      ));
+    }
+
+    if ((key1 == LogicalKeyboardKey.arrowRight ||
+                key1 == LogicalKeyboardKey.keyD) &&
+            (key2 == LogicalKeyboardKey.arrowUp ||
+                key2 == LogicalKeyboardKey.keyW) ||
+        (key2 == LogicalKeyboardKey.arrowRight ||
+                key2 == LogicalKeyboardKey.keyD) &&
+            (key1 == LogicalKeyboardKey.arrowUp ||
+                key1 == LogicalKeyboardKey.keyW)) {
       joystickChangeDirectional(JoystickDirectionalEvent(
         directional: JoystickMoveDirectional.MOVE_UP_RIGHT,
         intensity: 1.0,

--- a/lib/joystick/joystick.dart
+++ b/lib/joystick/joystick.dart
@@ -12,7 +12,7 @@ class KeyboardConfig {
   /// Use to enable ou disable keyboard events
   final bool enable;
 
-  /// Type of the directional (arrows, wasd or wasdAndArrow)
+  /// Type of the directional (arrows, wasd or wasdAndArrows)
   final KeyboardDirectionalType keyboardDirectionalType;
 
   /// You can pass specific Keys accepted. If null accept all keys

--- a/lib/util/talk/talk_dialog.dart
+++ b/lib/util/talk/talk_dialog.dart
@@ -11,7 +11,7 @@ class TalkDialog extends StatefulWidget {
     this.finish,
     this.onChangeTalk,
     this.textBoxMinHeight = 100,
-    this.keyboardKeyToNext,
+    this.keyboardKeysToNext,
     this.padding,
   }) : super(key: key);
 
@@ -22,7 +22,7 @@ class TalkDialog extends StatefulWidget {
     ValueChanged<int>? onChangeTalk,
     Color? backgroundColor,
     double boxTextHeight = 100,
-    LogicalKeyboardKey? logicalKeyboardKeyToNext,
+    List<LogicalKeyboardKey>? logicalKeyboardKeysToNext,
     EdgeInsetsGeometry? padding,
   }) {
     showDialog(
@@ -34,7 +34,7 @@ class TalkDialog extends StatefulWidget {
           finish: finish,
           onChangeTalk: onChangeTalk,
           textBoxMinHeight: boxTextHeight,
-          keyboardKeyToNext: logicalKeyboardKeyToNext,
+          keyboardKeysToNext: logicalKeyboardKeysToNext,
           padding: padding,
         );
       },
@@ -45,7 +45,7 @@ class TalkDialog extends StatefulWidget {
   final VoidCallback? finish;
   final ValueChanged<int>? onChangeTalk;
   final double? textBoxMinHeight;
-  final LogicalKeyboardKey? keyboardKeyToNext;
+  final List<LogicalKeyboardKey>? keyboardKeysToNext;
   final EdgeInsetsGeometry? padding;
 
   @override
@@ -85,13 +85,13 @@ class _TalkDialogState extends State<TalkDialog> {
       child: RawKeyboardListener(
         focusNode: _focusNode,
         onKey: (raw) {
-          if (widget.keyboardKeyToNext == null && raw is RawKeyDownEvent) {
+          if (widget.keyboardKeysToNext == null && raw is RawKeyDownEvent) {
             // Prevent volume buttons from triggering the next dialog
             if (raw.logicalKey != LogicalKeyboardKey.audioVolumeUp &&
                 raw.logicalKey != LogicalKeyboardKey.audioVolumeDown) {
               _nextOrFinish();
             }
-          } else if (raw.logicalKey == widget.keyboardKeyToNext &&
+          } else if (widget.keyboardKeysToNext!.contains(raw.logicalKey) &&
               raw is RawKeyDownEvent) {
             _nextOrFinish();
           }


### PR DESCRIPTION
# Description

**Suggestion**: We can start merging PRs with the squash option (selectable in the merge button dropdown) so every commit in the PR is grouped into a single commit, just like the Flame team does in their project.

This PR:
- Changes `logicalKeyboardKeyToNext` in `TalkDialog` to `logicalKeyboardKeysToNext` and now takes a List of keys to advance dialogue (Breaking Change, now it requires a `List<LogicalKeyboardKey>?` instead of `LogicalKeyboardKey?`);
-  Adds the option `wasdAndArrows` to `KeyboardDirectionalType` allowing both arrows and wasd keys to control the joystick.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I open this PR to `develop` branch.
- [X] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [X] I ran `flutter format --set-exit-if-changed --dry-run` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.