### PR TITLE
Version 1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [NEXT]
+- Adds support to add objects with collision by Tiled. Just add the object and set you type to `collision`.
+
 # [1.12.1]
 - improvements in sprite load of the `BackgroundImageGame`.
 - improvements in `simpleAttackRangeByAngle`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # [NEXT]
-- Adds support to add objects with collision by Tiled. Just add the object and set you type to `collision`.
+- Adds support to add objects with collision by Tiled. Just add the object and set you type to `collision`. [#210](https://github.com/RafaelBarbosatec/bonfire/issues/210)
 
 # [1.12.1]
 - improvements in sprite load of the `BackgroundImageGame`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [NEXT]
+# [1.12.2]
 - Adds support to add objects with collision by Tiled. Just add the object and set you type to `collision`. [#210](https://github.com/RafaelBarbosatec/bonfire/issues/210)
 - Improvements in `worldPositionToScreen`. Now considers zoom.
 - Improvements in `seeAndMoveToPlayer` and `seeAndMoveToAttackRange`. Adds `notObserved` and `observed`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [NEXT]
 - Adds support to add objects with collision by Tiled. Just add the object and set you type to `collision`. [#210](https://github.com/RafaelBarbosatec/bonfire/issues/210)
+- Improvements in `worldPositionToScreen`. Now considers zoom.
+- Improvements in `seeAndMoveToPlayer` and `seeAndMoveToAttackRange`. Adds `notObserved` and `observed`.
 
 # [1.12.1]
 - improvements in sprite load of the `BackgroundImageGame`.

--- a/example/assets/images/tiled/mapa1.json
+++ b/example/assets/images/tiled/mapa1.json
@@ -792,7 +792,7 @@
          "y":0
         }],
  "nextlayerid":14,
- "nextobjectid":82,
+ "nextobjectid":85,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.5.0",

--- a/example/lib/shared/enemy/goblin.dart
+++ b/example/lib/shared/enemy/goblin.dart
@@ -12,8 +12,7 @@ class Goblin extends SimpleEnemy
         MovementByJoystick,
         AutomaticRandomMovement {
   double attack = 20;
-  bool _seePlayerClose = false;
-  bool _seePlayerAway = false;
+  bool _seePlayerToAttackMelee = false;
   bool enableBehaviors = true;
 
   Goblin(Vector2 position)
@@ -49,43 +48,32 @@ class Goblin extends SimpleEnemy
     if (this.isDead) return;
     if (!enableBehaviors) return;
 
-    _seePlayerClose = false;
-    _seePlayerAway = false;
+    _seePlayerToAttackMelee = false;
 
-    this.seePlayer(
-      observed: (player) {
-        _seePlayerClose = true;
-        this.seeAndMoveToPlayer(
-          closePlayer: (player) {
-            execAttack();
-          },
-          radiusVision: DungeonMap.tileSize * 1.5,
-        );
+    this.seeAndMoveToPlayer(
+      closePlayer: (player) {
+        execAttack();
+      },
+      observed: () {
+        _seePlayerToAttackMelee = true;
       },
       radiusVision: DungeonMap.tileSize * 1.5,
     );
 
-    if (!_seePlayerClose) {
-      seePlayer(
+    if (!_seePlayerToAttackMelee) {
+      this.seeAndMoveToAttackRange(
+        minDistanceFromPlayer: DungeonMap.tileSize * 2,
+        positioned: (p) {
+          execAttackRange();
+        },
         radiusVision: DungeonMap.tileSize * 3,
-        observed: (p) {
-          _seePlayerAway = true;
-          this.seeAndMoveToAttackRange(
-            minDistanceFromPlayer: DungeonMap.tileSize * 2,
-            positioned: (p) {
-              execAttackRange();
-            },
-            radiusVision: DungeonMap.tileSize * 3,
+        notObserved: () {
+          runRandomMovement(
+            dt,
+            speed: speed / 2,
+            maxDistance: (DungeonMap.tileSize * 3).toInt(),
           );
         },
-      );
-    }
-
-    if (!_seePlayerAway && !_seePlayerClose) {
-      runRandomMovement(
-        dt,
-        speed: speed / 2,
-        maxDistance: (DungeonMap.tileSize * 3).toInt(),
       );
     }
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.12.0"
+    version: "1.12.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -360,7 +360,7 @@ packages:
       name: tiledjsonreader
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   typed_data:
     dependency: transitive
     description:

--- a/lib/camera/camera.dart
+++ b/lib/camera/camera.dart
@@ -346,15 +346,17 @@ class Camera with BonfireHasGameRef {
   }
 
   Offset worldPositionToScreen(Offset position) {
-    return position.translate(
-      this.cameraRect.left * -1,
-      this.cameraRect.top * -1,
+    double diffX = position.dx - this.cameraRect.center.dx;
+    double diffY = position.dy - this.cameraRect.center.dy;
+    return Offset(
+      (diffX * config.zoom) + (gameRef.size.x / 2),
+      (diffY * config.zoom) + (gameRef.size.y / 2),
     );
   }
 
   Offset screenPositionToWorld(Offset position) {
-    double diffX = position.dx - gameRef.size.x / 2;
-    double diffY = position.dy - gameRef.size.y / 2;
+    double diffX = position.dx - (gameRef.size.x / 2);
+    double diffY = position.dy - (gameRef.size.y / 2);
     return Offset(
       this.cameraRect.center.dx + (diffX / config.zoom),
       this.cameraRect.center.dy + (diffY / config.zoom),

--- a/lib/util/collision_game_component.dart
+++ b/lib/util/collision_game_component.dart
@@ -1,0 +1,35 @@
+import 'package:bonfire/base/game_component.dart';
+import 'package:bonfire/bonfire.dart';
+import 'package:bonfire/collision/object_collision.dart';
+import 'package:flame/extensions.dart';
+
+///
+/// Created by
+///
+/// ─▄▀─▄▀
+/// ──▀──▀
+/// █▀▀▀▀▀█▄
+/// █░░░░░█─█
+/// ▀▄▄▄▄▄▀▀
+///
+/// Rafaelbarbosatec
+/// on 10/12/21
+
+class CollisionGameComponent extends GameComponent with ObjectCollision {
+  final String name;
+  final Map<String, dynamic>? properties;
+
+  CollisionGameComponent({
+    this.name = '',
+    this.properties,
+    required Vector2 position,
+    List<CollisionArea> collisions = const [],
+  }) {
+    this.position = this.position.copyWith(
+          position: position,
+        );
+    setupCollision(
+      CollisionConfig(collisions: collisions),
+    );
+  }
+}

--- a/lib/util/extensions/enemy/enemy_extensions.dart
+++ b/lib/util/extensions/enemy/enemy_extensions.dart
@@ -39,6 +39,8 @@ extension EnemyExtensions on Enemy {
   /// Checks whether the player is within range. If so, move to it.
   void seeAndMoveToPlayer({
     required Function(Player) closePlayer,
+    VoidCallback? notObserved,
+    VoidCallback? observed,
     double radiusVision = 32,
     double margin = 10,
     bool runOnlyVisibleInScreen = true,
@@ -49,6 +51,7 @@ extension EnemyExtensions on Enemy {
     seePlayer(
       radiusVision: radiusVision,
       observed: (player) {
+        observed?.call();
         this.followComponent(
           player,
           dtUpdate,
@@ -60,6 +63,7 @@ extension EnemyExtensions on Enemy {
         if (!this.isIdle) {
           this.idle();
         }
+        notObserved?.call();
       },
     );
   }
@@ -155,6 +159,8 @@ extension EnemyExtensions on Enemy {
   /// Checks whether the player is within range. If so, move to it.
   void seeAndMoveToAttackRange({
     required Function(Player) positioned,
+    VoidCallback? notObserved,
+    VoidCallback? observed,
     double radiusVision = 32,
     double? minDistanceFromPlayer,
     bool runOnlyVisibleInScreen = true,
@@ -164,6 +170,7 @@ extension EnemyExtensions on Enemy {
     seePlayer(
       radiusVision: radiusVision,
       observed: (player) {
+        observed?.call();
         this.positionsItselfAndKeepDistance(
           player,
           minDistanceFromPlayer: minDistanceFromPlayer,
@@ -185,6 +192,7 @@ extension EnemyExtensions on Enemy {
         if (!this.isIdle) {
           this.idle();
         }
+        notObserved?.call();
       },
     );
   }

--- a/lib/util/text_game_component.dart
+++ b/lib/util/text_game_component.dart
@@ -17,9 +17,11 @@ import 'package:flutter/material.dart';
 class TextGameComponent extends GameComponent {
   TextPaint? _textPaint;
   final String text;
+  final String name;
   TextGameComponent({
     required this.text,
     required Vector2 position,
+    this.name = '',
     TextStyle? style,
   }) {
     this.position = this.position.copyWith(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,7 +169,7 @@ packages:
       name: tiledjsonreader
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bonfire
 description: (RPG maker) Create RPG-style or similar games more simply with Flame.
-version: 1.12.1
+version: 1.12.2
 homepage: https://github.com/RafaelBarbosatec/bonfire
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   flame: 1.0.0-releasecandidate.17
-  tiledjsonreader: 1.0.8
+  tiledjsonreader: 1.0.9
   http: 0.13.4
   a_star_algorithm: 0.1.1
 


### PR DESCRIPTION
- Adds support to add objects with collision by Tiled. Just add the object and set you type to `collision`. [#210](https://github.com/RafaelBarbosatec/bonfire/issues/210)
- Improvements in `worldPositionToScreen`. Now considers zoom.
- Improvements in `seeAndMoveToPlayer` and `seeAndMoveToAttackRange`. Adds `notObserved` and `observed`.