### PR TITLE
Feature/expand follower mixin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [next]
+- Expand follower mixin support
+
 # [2.4.2]
 - Adds params `focusNode`, `autofocus` and `mouseCursor` in `BonfireWidget` and `BonfireTiledWidget`
 - Improvements in `Camera`

--- a/lib/util/mixins/follower.dart
+++ b/lib/util/mixins/follower.dart
@@ -1,4 +1,3 @@
-import 'package:bonfire/base/game_component.dart';
 import 'package:flame/components.dart';
 
 ///
@@ -12,12 +11,12 @@ import 'package:flame/components.dart';
 ///
 /// Rafaelbarbosatec
 /// on 04/02/22
-mixin Follower on GameComponent {
-  GameComponent? followerTarget;
+mixin Follower on PositionComponent {
+  PositionComponent? followerTarget;
   Vector2? followerPositionFromTarget;
 
   void setupFollower(
-    GameComponent followerTarget, {
+    PositionComponent followerTarget, {
     Vector2? followerPositionFromTarget,
   }) {
     this.followerTarget = followerTarget;


### PR DESCRIPTION
# Description

I wanted to make a chat box that shows above and follows game characters, but follower mixin can be only used with Game Components.
By changing mixin to extend on PositionComponent, non GameComponents such as TextBoxComponent can follow other position components.

Available use cases
ex) chat text box for game characters, damage text box


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.