### PR TITLE
Version 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # [NEXT]
 - Improvement in `JoystickMoveToPosition`. New:
-    - adds `enabledMoveCameraWithClick` param to enable movements of the camera with click and move.movements
+    - adds `enabledMoveCameraWithClick` param to enable movements of the camera with click and move movements.
     - adds `mouseButtonUsedToMoveCamera` param to set what button of the mouse you can use to move the camera.
-    - adds `mouseButtonUseToMoveToPosition` param to set what button of the mouse you can use to set the position target. Default is `secondary` (right mouse button).
+    - adds `mouseButtonUsedToMoveToPosition` param to set what button of the mouse you can use to set the position target. Default is `secondary` (right mouse button).
 - Extracted functions about check `Tiles` to the mixin `TileRecognizer`.
 
 # [2.4.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [NEXT]
+# [2.4.3]
 - Improvement in `JoystickMoveToPosition`. New:
     - adds `enabledMoveCameraWithClick` param to enable movements of the camera with click and move movements.
     - adds `mouseButtonUsedToMoveCamera` param to set what button of the mouse you can use to move the camera.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - adds `enabledMoveCameraWithClick` param to enable movements of the camera with click and move.movements
     - adds `mouseButtonUsedToMoveCamera` param to set what button of the mouse you can use to move the camera.
     - adds `mouseButtonUseToMoveToPosition` param to set what button of the mouse you can use to set the position target. Default is `secondary` (right mouse button).
+- Extracted functions about check `Tiles` to the mixin `TileRecognizer`.
 
 # [2.4.2]
 - Adds params `focusNode`, `autofocus` and `mouseCursor` in `BonfireWidget` and `BonfireTiledWidget`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [NEXT]
+- Improvement in `JoystickMoveToPosition`. New:
+    - adds `enabledMoveCameraWithClick` param to enable movements of the camera with click and move.movements
+    - adds `mouseButtonUsedToMoveCamera` param to set what button of the mouse you can use to move the camera.
+    - adds `mouseButtonUseToMoveToPosition` param to set what button of the mouse you can use to set the position target.
+
 # [2.4.2]
 - Adds params `focusNode`, `autofocus` and `mouseCursor` in `BonfireWidget` and `BonfireTiledWidget`
 - Improvements in `Camera`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Improvement in `JoystickMoveToPosition`. New:
     - adds `enabledMoveCameraWithClick` param to enable movements of the camera with click and move.movements
     - adds `mouseButtonUsedToMoveCamera` param to set what button of the mouse you can use to move the camera.
-    - adds `mouseButtonUseToMoveToPosition` param to set what button of the mouse you can use to set the position target.
+    - adds `mouseButtonUseToMoveToPosition` param to set what button of the mouse you can use to set the position target. Default is `secondary` (right mouse button).
 
 # [2.4.2]
 - Adds params `focusNode`, `autofocus` and `mouseCursor` in `BonfireWidget` and `BonfireTiledWidget`

--- a/example/lib/shared/decoration/spikes.dart
+++ b/example/lib/shared/decoration/spikes.dart
@@ -23,7 +23,11 @@ class Spikes extends GameDecoration with Sensor {
   @override
   void onContact(GameComponent component) {
     if (component is Attackable) {
-      component.receiveDamage(AttackFromEnum.ENEMY, 10, 1);
+      if (component is Player) {
+        component.receiveDamage(AttackFromEnum.ENEMY, 10, 1);
+      } else {
+        component.receiveDamage(AttackFromEnum.PLAYER_OR_ALLY, 10, 1);
+      }
     }
   }
 

--- a/example/lib/shared/enemy/goblin.dart
+++ b/example/lib/shared/enemy/goblin.dart
@@ -105,15 +105,15 @@ class Goblin extends SimpleEnemy
   }
 
   @override
-  void receiveDamage(AttackFromEnum attacker, double damage, dynamic identify) {
+  void removeLife(double life) {
     this.showDamage(
-      damage,
+      life,
       config: TextStyle(
         fontSize: width / 3,
         color: Colors.white,
       ),
     );
-    super.receiveDamage(attacker, damage, identify);
+    super.removeLife(life);
   }
 
   @override

--- a/example/lib/tiled_map/game_tiled_map.dart
+++ b/example/lib/tiled_map/game_tiled_map.dart
@@ -90,7 +90,9 @@ class GameTiledMap extends StatelessWidget {
                   game: game,
                   margin: EdgeInsets.all(20),
                   borderRadius: BorderRadius.circular(10),
-                  size: Vector2.all(constraints.maxHeight / 3),
+                  size: Vector2.all(
+                    min(constraints.maxHeight, constraints.maxWidth) / 3,
+                  ),
                   border: Border.all(color: Colors.white.withOpacity(0.5)),
                 ),
           },

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:

--- a/lib/base/game_component.dart
+++ b/lib/base/game_component.dart
@@ -42,12 +42,6 @@ abstract class GameComponent extends PositionComponent
   /// Get BuildContext
   BuildContext get context => gameRef.context;
 
-  /// Method that checks if this component is visible on the screen
-  bool _isVisibleInCamera() {
-    if (!hasGameRef) return false;
-    return gameRef.isVisibleInCamera(this);
-  }
-
   /// Method that checks if this component contain collisions
   bool isObjectCollision() {
     return (this is ObjectCollision &&
@@ -183,8 +177,7 @@ abstract class GameComponent extends PositionComponent
       _intervalCheckIsVisible,
       dt,
     )) {
-      isVisible =
-          this._isVisibleInCamera() || positionType == PositionType.viewport;
+      isVisible = this._isVisibleInCamera();
     }
   }
 
@@ -224,6 +217,13 @@ abstract class GameComponent extends PositionComponent
         i.handlerPointerCancel(event);
       }
     });
+  }
+
+  /// Method that checks if this component is visible on the screen
+  bool _isVisibleInCamera() {
+    if (!hasGameRef) return false;
+    return gameRef.isVisibleInCamera(this) ||
+        positionType == PositionType.viewport;
   }
 
   void _applyFlipAndRotation(Canvas canvas) {

--- a/lib/base/game_component.dart
+++ b/lib/base/game_component.dart
@@ -42,66 +42,6 @@ abstract class GameComponent extends PositionComponent
   /// Get BuildContext
   BuildContext get context => gameRef.context;
 
-  /// Method that checks if this component contain collisions
-  bool isObjectCollision() {
-    return (this is ObjectCollision &&
-        (this as ObjectCollision).containCollision());
-  }
-
-  /// Method that checks what type map tile is currently
-  String? tileTypeBelow() {
-    final list = tileTypeListBelow();
-    if (list.isNotEmpty) {
-      return list.first;
-    }
-
-    return null;
-  }
-
-  /// Method that checks what types map tile is currently
-  List<String> tileTypeListBelow() {
-    if (!hasGameRef) return [];
-    final map = gameRef.map;
-    if (map.getRendered().isNotEmpty) {
-      return map
-          .getRendered()
-          .where((element) {
-            return (element.overlaps(rectConsideringCollision) &&
-                (element.type?.isNotEmpty ?? false));
-          })
-          .map<String>((e) => e.type!)
-          .toList();
-    }
-    return [];
-  }
-
-  /// Method that checks what properties map tile is currently
-  Map<String, dynamic>? tilePropertiesBelow() {
-    final list = tilePropertiesListBelow();
-    if (list?.isNotEmpty == true) {
-      return list?.first;
-    }
-
-    return null;
-  }
-
-  /// Method that checks what properties list map tile is currently
-  List<Map<String, dynamic>>? tilePropertiesListBelow() {
-    if (!hasGameRef) return null;
-    final map = gameRef.map;
-    if (map.tiles.isNotEmpty) {
-      return map
-          .getRendered()
-          .where((element) {
-            return (element.overlaps(rectConsideringCollision) &&
-                (element.properties != null));
-          })
-          .map<Map<String, dynamic>>((e) => e.properties!)
-          .toList();
-    }
-    return null;
-  }
-
   /// Method used to translate component
   void translate(double translateX, double translateY) {
     position.add(Vector2(translateX, translateY));
@@ -183,13 +123,12 @@ abstract class GameComponent extends PositionComponent
 
   /// Return screen position of this component.
   Vector2 screenPosition() {
-    if (hasGameRef) {
-      return gameRef.camera.worldToScreen(
-        position,
-      );
-    } else {
+    if (!hasGameRef) {
       return Vector2.zero();
     }
+    return gameRef.camera.worldToScreen(
+      position,
+    );
   }
 
   @override

--- a/lib/base/game_component.dart
+++ b/lib/base/game_component.dart
@@ -147,29 +147,16 @@ abstract class GameComponent extends PositionComponent
   @override
   void renderTree(Canvas canvas) {
     canvas.save();
-
-    if (isFlipHorizontal || isFlipVertical || angle != 0) {
-      canvas.translate(this.center.x, this.center.y);
-      if (angle != 0) {
-        canvas.rotate(angle);
-      }
-      if (isFlipHorizontal || isFlipVertical) {
-        canvas.scale(isFlipHorizontal ? -1 : 1, isFlipVertical ? -1 : 1);
-      }
-
-      canvas.translate(-this.center.x, -this.center.y);
-    }
-
+    _applyFlipAndRotation(canvas);
     render(canvas);
-
-    canvas.restore();
-
     children.forEach((c) => c.renderTree(canvas));
 
     // Any debug rendering should be rendered on top of everything
     if (debugMode) {
       renderDebugMode(canvas);
     }
+
+    canvas.restore();
   }
 
   /// Returns true if for each time the defined millisecond interval passes.
@@ -187,6 +174,10 @@ abstract class GameComponent extends PositionComponent
   @override
   void update(double dt) {
     super.update(dt);
+    _checkIsVisible(dt);
+  }
+
+  void _checkIsVisible(double dt) {
     if (checkInterval(
       _keyIntervalCheckIsVisible,
       _intervalCheckIsVisible,
@@ -233,5 +224,19 @@ abstract class GameComponent extends PositionComponent
         i.handlerPointerCancel(event);
       }
     });
+  }
+
+  void _applyFlipAndRotation(Canvas canvas) {
+    if (isFlipHorizontal || isFlipVertical || angle != 0) {
+      canvas.translate(this.center.x, this.center.y);
+      if (angle != 0) {
+        canvas.rotate(angle);
+      }
+      if (isFlipHorizontal || isFlipVertical) {
+        canvas.scale(isFlipHorizontal ? -1 : 1, isFlipVertical ? -1 : 1);
+      }
+
+      canvas.translate(-this.center.x, -this.center.y);
+    }
   }
 }

--- a/lib/bonfire.dart
+++ b/lib/bonfire.dart
@@ -59,6 +59,7 @@ export 'package:bonfire/util/mixins/movement.dart';
 export 'package:bonfire/util/mixins/movement_by_joystick.dart';
 export 'package:bonfire/util/mixins/pushable.dart';
 export 'package:bonfire/util/mixins/sensor.dart';
+export 'package:bonfire/util/mixins/tile_recognizer.dart';
 export 'package:bonfire/util/mixins/use_assets_loader.dart';
 export 'package:bonfire/util/mixins/use_sprite.dart';
 export 'package:bonfire/util/mixins/use_sprite_animation.dart';

--- a/lib/bonfire.dart
+++ b/lib/bonfire.dart
@@ -54,6 +54,7 @@ export 'package:bonfire/util/interval_tick.dart';
 export 'package:bonfire/util/mixins/attackable.dart';
 export 'package:bonfire/util/mixins/automatic_random_movement.dart';
 export 'package:bonfire/util/mixins/follower.dart';
+export 'package:bonfire/util/mixins/interval_checker.dart';
 export 'package:bonfire/util/mixins/move_to_position_along_the_path.dart';
 export 'package:bonfire/util/mixins/movement.dart';
 export 'package:bonfire/util/mixins/movement_by_joystick.dart';

--- a/lib/camera/bonfire_camera.dart
+++ b/lib/camera/bonfire_camera.dart
@@ -56,6 +56,10 @@ class BonfireCamera extends Camera {
     snapTo(position.translate(displacement, 0));
   }
 
+  void moveLeft(double displacement) {
+    snapTo(position.translate(displacement * -1, 0));
+  }
+
   void moveDown(double displacement) {
     snapTo(position.translate(0, displacement));
   }

--- a/lib/collision/collision_area.dart
+++ b/lib/collision/collision_area.dart
@@ -2,7 +2,7 @@ import 'package:bonfire/bonfire.dart';
 import 'package:bonfire/geometry/shape.dart';
 import 'package:flutter/widgets.dart';
 
-Paint _paintCollision = Paint();
+final Paint _paintCollision = Paint();
 
 class CollisionArea {
   final Shape shape;

--- a/lib/collision/collision_config.dart
+++ b/lib/collision/collision_config.dart
@@ -19,13 +19,14 @@ class CollisionConfig {
   });
 
   bool verifyCollision(CollisionConfig? other, {Vector2? displacement}) {
-    if (other == null) return false;
-    for (final element1 in collisions) {
-      for (final element2 in other.collisions) {
-        if (displacement != null
-            ? element1.verifyCollisionSimulate(displacement, element2)
-            : element1.verifyCollision(element2)) {
-          return true;
+    if (other != null) {
+      for (final element1 in collisions) {
+        for (final element2 in other.collisions) {
+          if (displacement != null
+              ? element1.verifyCollisionSimulate(displacement, element2)
+              : element1.verifyCollision(element2)) {
+            return true;
+          }
         }
       }
     }
@@ -36,7 +37,7 @@ class CollisionConfig {
     if (collisions.isNotEmpty && position != _lastPosition) {
       collisions.first.updatePosition(position);
       Rect? _rect;
-      for (final element in collisions) {
+      for (var element in collisions) {
         element.updatePosition(position);
         if (_rect == null) {
           _rect = element.rect;

--- a/lib/collision/object_collision.dart
+++ b/lib/collision/object_collision.dart
@@ -102,34 +102,32 @@ mixin ObjectCollision on GameComponent {
   @override
   void render(Canvas canvas) {
     super.render(canvas);
-    if (hasGameRef) {
-      if (gameRef.showCollisionArea == true) {
-        renderCollision(
-          canvas,
-          gameRef.collisionAreaColor ?? Colors.lightGreen.withOpacity(0.5),
-        );
-      }
+    if (hasGameRef && gameRef.showCollisionArea == true) {
+      renderCollision(
+        canvas,
+        gameRef.collisionAreaColor ?? Colors.lightGreen.withOpacity(0.5),
+      );
     }
   }
 
   void renderCollision(Canvas canvas, Color color) {
-    if (!containCollision()) return;
-
-    for (final element in _collisionConfig!.collisions) {
-      element.render(canvas, color);
+    if (containCollision()) {
+      for (final element in _collisionConfig!.collisions) {
+        element.render(canvas, color);
+      }
     }
   }
 
   @override
   void update(double dt) {
-    updatePosition(this.position);
-    _containCollision = _collisionConfig?.collisions != null &&
-        _collisionConfig?.collisions.isNotEmpty == true &&
-        _collisionConfig?.enable == true;
+    _collisionConfig?.updatePosition(position);
+    _verifyIfContainCollision();
     super.update(dt);
   }
 
-  void updatePosition(Vector2 position) {
-    _collisionConfig?.updatePosition(position);
+  void _verifyIfContainCollision() {
+    _containCollision = _collisionConfig?.collisions != null &&
+        _collisionConfig?.collisions.isNotEmpty == true &&
+        _collisionConfig?.enable == true;
   }
 }

--- a/lib/joystick/joystick_move_to_position.dart
+++ b/lib/joystick/joystick_move_to_position.dart
@@ -6,7 +6,7 @@ enum MouseButton { primary, secondary, tertiary }
 class JoystickMoveToPosition extends JoystickController {
   final bool enabledMoveCameraWithClick;
   final MouseButton mouseButtonUsedToMoveCamera;
-  final MouseButton mouseButtonUseToMoveToPosition;
+  final MouseButton mouseButtonUsedToMoveToPosition;
   int? _pointer;
   bool _interfaceReceiveInteraction = false;
   bool _initMove = false;
@@ -17,7 +17,7 @@ class JoystickMoveToPosition extends JoystickController {
   JoystickMoveToPosition({
     this.enabledMoveCameraWithClick = false,
     this.mouseButtonUsedToMoveCamera = MouseButton.primary,
-    this.mouseButtonUseToMoveToPosition = MouseButton.secondary,
+    this.mouseButtonUsedToMoveToPosition = MouseButton.secondary,
   });
 
   @override
@@ -27,7 +27,7 @@ class JoystickMoveToPosition extends JoystickController {
     _startCameraPosition = gameRef.camera.position;
     _actionMoveToPosition = _acceptFromMouse(
       event,
-      mouseButtonUseToMoveToPosition,
+      mouseButtonUsedToMoveToPosition,
     );
     super.handlerPointerDown(event);
     _interfaceReceiveInteraction =

--- a/lib/joystick/joystick_move_to_position.dart
+++ b/lib/joystick/joystick_move_to_position.dart
@@ -1,22 +1,60 @@
 import 'package:bonfire/bonfire.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+
+enum MouseButton { primary, secondary, tertiary }
 
 class JoystickMoveToPosition extends JoystickController {
+  final bool enabledMoveCameraWithClick;
+  final MouseButton mouseButtonUsedToMoveCamera;
+  final MouseButton mouseButtonUseToMoveToPosition;
   int? _pointer;
   bool _interfaceReceiveInteraction = false;
+  bool _initMove = false;
+  bool _actionMoveToPosition = false;
+  Vector2 _startPoint = Vector2.zero();
+  Vector2 _startCameraPosition = Vector2.zero();
+
+  JoystickMoveToPosition({
+    this.enabledMoveCameraWithClick = false,
+    this.mouseButtonUsedToMoveCamera = MouseButton.primary,
+    this.mouseButtonUseToMoveToPosition = MouseButton.secondary,
+  });
 
   @override
   void handlerPointerDown(PointerDownEvent event) {
     _pointer = event.pointer;
+    _startPoint = event.position.toVector2();
+    _startCameraPosition = gameRef.camera.position;
+    _actionMoveToPosition = _acceptFromMouse(
+      event,
+      mouseButtonUseToMoveToPosition,
+    );
     super.handlerPointerDown(event);
     _interfaceReceiveInteraction =
         gameRef.interface?.receiveInteraction ?? false;
   }
 
   @override
+  void handlerPointerMove(PointerMoveEvent event) {
+    double distance = _startPoint.distanceTo(event.position.toVector2());
+    if (distance > 1) {
+      _initMove = true;
+
+      if (enabledMoveCameraWithClick &&
+          _acceptFromMouse(event, mouseButtonUsedToMoveCamera)) {
+        double px = _startPoint.x - event.position.dx;
+        double py = _startPoint.y - event.position.dy;
+        gameRef.camera.target = null;
+        gameRef.camera.snapTo(_startCameraPosition.translate(px, py));
+      }
+    }
+
+    super.handlerPointerMove(event);
+  }
+
+  @override
   void handlerPointerUp(PointerUpEvent event) {
-    if (_pointer == event.pointer) {
+    if (_pointer == event.pointer && !_initMove && _actionMoveToPosition) {
       if (!_interfaceReceiveInteraction) {
         final absolutePosition =
             this.gameRef.screenToWorld(event.position.toVector2());
@@ -24,6 +62,30 @@ class JoystickMoveToPosition extends JoystickController {
       }
     }
     _interfaceReceiveInteraction = false;
+    _initMove = false;
     super.handlerPointerUp(event);
+  }
+
+  bool _acceptFromMouse(PointerEvent event, MouseButton button) {
+    bool isMouse = event.kind == PointerDeviceKind.mouse;
+
+    if (!isMouse) {
+      return true;
+    }
+    if (event.buttons == _getButtonByEnum(button)) {
+      return true;
+    }
+    return false;
+  }
+
+  int _getButtonByEnum(MouseButton button) {
+    switch (button) {
+      case MouseButton.primary:
+        return 1;
+      case MouseButton.secondary:
+        return 2;
+      case MouseButton.tertiary:
+        return 4;
+    }
   }
 }

--- a/lib/util/direction_animations/simple_direction_animation.dart
+++ b/lib/util/direction_animations/simple_direction_animation.dart
@@ -78,10 +78,12 @@ class SimpleDirectionAnimation {
     _loader?.add(AssetToLoad(idleUp, (value) => this.idleUp = value));
     _loader?.add(AssetToLoad(idleUpLeft, (value) => this.idleUpLeft = value));
     _loader?.add(AssetToLoad(idleUpRight, (value) => this.idleUpRight = value));
-    _loader
-        ?.add(AssetToLoad(idleDownLeft, (value) => this.idleDownLeft = value));
     _loader?.add(
-        AssetToLoad(idleDownRight, (value) => this.idleDownRight = value));
+      AssetToLoad(idleDownLeft, (value) => this.idleDownLeft = value),
+    );
+    _loader?.add(
+      AssetToLoad(idleDownRight, (value) => this.idleDownRight = value),
+    );
     _loader?.add(AssetToLoad(runUp, (value) => this.runUp = value));
     _loader?.add(AssetToLoad(runRight, (value) => this.runRight = value));
     _loader?.add(AssetToLoad(runDown, (value) => this.runDown = value));
@@ -89,8 +91,9 @@ class SimpleDirectionAnimation {
     _loader?.add(AssetToLoad(runUpLeft, (value) => this.runUpLeft = value));
     _loader?.add(AssetToLoad(runUpRight, (value) => this.runUpRight = value));
     _loader?.add(AssetToLoad(runDownLeft, (value) => this.runDownLeft = value));
-    _loader
-        ?.add(AssetToLoad(runDownRight, (value) => this.runDownRight = value));
+    _loader?.add(
+      AssetToLoad(runDownRight, (value) => this.runDownRight = value),
+    );
 
     others?.forEach((key, anim) {
       _loader?.add(AssetToLoad(anim, (value) {

--- a/lib/util/direction_animations/simple_direction_animation.dart
+++ b/lib/util/direction_animations/simple_direction_animation.dart
@@ -68,12 +68,10 @@ class SimpleDirectionAnimation {
     FutureOr<SpriteAnimation>? runDownLeft,
     FutureOr<SpriteAnimation>? runDownRight,
     Map<String, FutureOr<SpriteAnimation>>? others,
-    SimpleAnimationEnum initAnimation = SimpleAnimationEnum.idleRight,
     this.enabledFlipX = true,
     this.enabledFlipY = false,
     this.eightDirection = false,
   }) {
-    _currentType = initAnimation;
     _loader?.add(AssetToLoad(idleLeft, (value) => this.idleLeft = value));
     _loader?.add(AssetToLoad(idleRight, (value) => this.idleRight = value));
     _loader?.add(AssetToLoad(idleDown, (value) => this.idleDown = value));

--- a/lib/util/extensions/extensions.dart
+++ b/lib/util/extensions/extensions.dart
@@ -409,6 +409,8 @@ extension CameraExt on Camera {
       (this as BonfireCamera).moveTop(displacement);
   void moveRight(double displacement) =>
       (this as BonfireCamera).moveRight(displacement);
+  void moveLeft(double displacement) =>
+      (this as BonfireCamera).moveLeft(displacement);
   void moveDown(double displacement) =>
       (this as BonfireCamera).moveDown(displacement);
   void moveUp(double displacement) =>

--- a/lib/util/extensions/game_component_extensions.dart
+++ b/lib/util/extensions/game_component_extensions.dart
@@ -465,4 +465,10 @@ extension GameComponentExtensions on GameComponent {
         ? (this as ObjectCollision).rectCollision
         : toRect());
   }
+
+  /// Method that checks if this component contain collisions
+  bool isObjectCollision() {
+    return (this is ObjectCollision &&
+        (this as ObjectCollision).containCollision());
+  }
 }

--- a/lib/util/mixins/interval_checker.dart
+++ b/lib/util/mixins/interval_checker.dart
@@ -1,0 +1,32 @@
+import 'package:bonfire/util/interval_tick.dart';
+
+///
+/// Created by
+///
+/// ─▄▀─▄▀
+/// ──▀──▀
+/// █▀▀▀▀▀█▄
+/// █░░░░░█─█
+/// ▀▄▄▄▄▄▀▀
+///
+/// Rafaelbarbosatec
+/// on 17/05/22
+mixin InternalChecker {
+  /// Map available to store times that can be used to control the frequency of any action.
+  Map<String, IntervalTick>? _timers;
+
+  /// Returns true if for each time the defined millisecond interval passes.
+  /// Like a `Timer.periodic`
+  /// Used in flows involved in the [update]
+  bool checkInterval(String key, int intervalInMilli, double dt) {
+    if (_timers == null) {
+      _timers = Map();
+    }
+    if (this._timers![key]?.interval != intervalInMilli) {
+      this._timers![key] = IntervalTick(intervalInMilli);
+      return true;
+    } else {
+      return this._timers![key]?.update(dt) ?? false;
+    }
+  }
+}

--- a/lib/util/mixins/move_to_position_along_the_path.dart
+++ b/lib/util/mixins/move_to_position_along_the_path.dart
@@ -50,6 +50,9 @@ mixin MoveToPositionAlongThePath on Movement {
     Vector2 position, {
     List? ignoreCollisions,
   }) {
+    if (!hasGameRef) {
+      return;
+    }
     this.ignoreCollisions.clear();
     this.ignoreCollisions.add(this);
     if (ignoreCollisions != null) {

--- a/lib/util/mixins/tile_recognizer.dart
+++ b/lib/util/mixins/tile_recognizer.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/base/game_component.dart';
+import 'package:bonfire/map/tile/tile.dart';
 import 'package:bonfire/util/extensions/game_component_extensions.dart';
 
 ///
@@ -28,14 +29,7 @@ mixin TileRecognizer on GameComponent {
     if (!hasGameRef) return [];
     final map = gameRef.map;
     if (map.getRendered().isNotEmpty) {
-      return map
-          .getRendered()
-          .where((element) {
-            return (element.overlaps(rectConsideringCollision) &&
-                (element.type?.isNotEmpty ?? false));
-          })
-          .map<String>((e) => e.type!)
-          .toList();
+      return tileListBelow().map<String>((e) => e.type!).toList();
     }
     return [];
   }
@@ -55,15 +49,23 @@ mixin TileRecognizer on GameComponent {
     if (!hasGameRef) return null;
     final map = gameRef.map;
     if (map.tiles.isNotEmpty) {
-      return map
-          .getRendered()
-          .where((element) {
-            return (element.overlaps(rectConsideringCollision) &&
-                (element.properties != null));
-          })
+      return tileListBelow()
           .map<Map<String, dynamic>>((e) => e.properties!)
           .toList();
     }
     return null;
+  }
+
+  /// Method that checks what map tiles is below
+  Iterable<Tile> tileListBelow() {
+    if (!hasGameRef) return [];
+    final map = gameRef.map;
+    if (map.tiles.isNotEmpty) {
+      return map.getRendered().where((element) {
+        return (element.overlaps(rectConsideringCollision) &&
+            (element.properties != null));
+      });
+    }
+    return [];
   }
 }

--- a/lib/util/mixins/tile_recognizer.dart
+++ b/lib/util/mixins/tile_recognizer.dart
@@ -1,0 +1,69 @@
+import 'package:bonfire/base/game_component.dart';
+import 'package:bonfire/util/extensions/game_component_extensions.dart';
+
+///
+/// Created by
+///
+/// ─▄▀─▄▀
+/// ──▀──▀
+/// █▀▀▀▀▀█▄
+/// █░░░░░█─█
+/// ▀▄▄▄▄▄▀▀
+///
+/// Rafaelbarbosatec
+/// on 16/05/22
+
+mixin TileRecognizer on GameComponent {
+  /// Method that checks what type map tile is currently
+  String? tileTypeBelow() {
+    final list = tileTypeListBelow();
+    if (list.isNotEmpty) {
+      return list.first;
+    }
+    return null;
+  }
+
+  /// Method that checks what types map tile is currently
+  List<String> tileTypeListBelow() {
+    if (!hasGameRef) return [];
+    final map = gameRef.map;
+    if (map.getRendered().isNotEmpty) {
+      return map
+          .getRendered()
+          .where((element) {
+            return (element.overlaps(rectConsideringCollision) &&
+                (element.type?.isNotEmpty ?? false));
+          })
+          .map<String>((e) => e.type!)
+          .toList();
+    }
+    return [];
+  }
+
+  /// Method that checks what properties map tile is currently
+  Map<String, dynamic>? tilePropertiesBelow() {
+    final list = tilePropertiesListBelow();
+    if (list?.isNotEmpty == true) {
+      return list?.first;
+    }
+
+    return null;
+  }
+
+  /// Method that checks what properties list map tile is currently
+  List<Map<String, dynamic>>? tilePropertiesListBelow() {
+    if (!hasGameRef) return null;
+    final map = gameRef.map;
+    if (map.tiles.isNotEmpty) {
+      return map
+          .getRendered()
+          .where((element) {
+            return (element.overlaps(rectConsideringCollision) &&
+                (element.properties != null));
+          })
+          .map<Map<String, dynamic>>((e) => e.properties!)
+          .toList();
+    }
+    return null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bonfire
 description: (RPG maker) Create RPG-style or similar games more simply with Flame.
-version: 2.4.2
+version: 2.4.3
 homepage: https://github.com/RafaelBarbosatec/bonfire
 
 environment:


### PR DESCRIPTION
- Improvement in `JoystickMoveToPosition`. New:
    - adds `enabledMoveCameraWithClick` param to enable movements of the camera with click and move movements.
    - adds `mouseButtonUsedToMoveCamera` param to set what button of the mouse you can use to move the camera.
    - adds `mouseButtonUsedToMoveToPosition` param to set what button of the mouse you can use to set the position target. Default is `secondary` (right mouse button).
- Extracted functions about check `Tiles` to the mixin `TileRecognizer`.