### PR TITLE
fix(map): :bug: Update moveOnlyMapArea limits after changing camera zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [next]
+- Fix: update map limits using `moveOnlyMapArea` after camera zoom changes. [#267](https://github.com/RafaelBarbosatec/bonfire/issues/267)
+
 # [2.6.2]
 - Updated example.
 - Remove mandatory of the `SimpleDirectionAnimation` in  `SimpleAlly`, `SimpleEnemy`, `SimpleNpc` and `SimplePlayer`

--- a/lib/camera/bonfire_camera.dart
+++ b/lib/camera/bonfire_camera.dart
@@ -14,7 +14,7 @@ class BonfireCamera extends Camera {
   GameComponent? target;
   late BonfireGame gameRef;
 
-  Size? _lastMapSize;
+  double? _lastZoomSize;
   double limitMinX = 0;
   double limitMinY = 0;
   double limitMaxX = 0;
@@ -369,8 +369,8 @@ class BonfireCamera extends Camera {
   void _updateLimits(Vector2 canvasSize) {
     final sizeMap = gameRef.map.getMapSize();
 
-    if (_lastMapSize != sizeMap && sizeMap != Size.zero) {
-      _lastMapSize = sizeMap;
+    if (_lastZoomSize != this.zoom && sizeMap != Size.zero) {
+      _lastZoomSize = this.zoom;
       final startPosition = gameRef.map.getStartPosition();
       limitMinX = startPosition.x;
       limitMinY = startPosition.y;

--- a/lib/map/map_world.dart
+++ b/lib/map/map_world.dart
@@ -324,11 +324,10 @@ class MapWorld extends MapGame {
 
   bool _checkNeedUpdateTiles() {
     final camera = _getCameraTileUpdate();
-    if (lastCamera != camera || lastMinorZoom > gameRef.camera.zoom) {
+    if (lastCamera != camera || lastMinorZoom != gameRef.camera.zoom) {
       lastCamera = camera;
-      if (lastMinorZoom > gameRef.camera.zoom) {
-        lastMinorZoom = gameRef.camera.zoom;
-      }
+      lastMinorZoom = gameRef.camera.zoom;
+
       return true;
     }
     return false;


### PR DESCRIPTION
# Description

When the BonfireCamera changes his zoom, the moveOnlyMapArea property wasn't updating his limits. I've fixed that in this PR.
When the camera zoom changes, the limits are updated too.

Previously, the way it was being done, this should be updated when the map size changes, but the map size never changes, only the zoom. I changed the logic of the function that does this to be based on changing the zoom, rather than changing the size of the map.

This closes the issue [#267](https://github.com/RafaelBarbosatec/bonfire/issues/267).

## Checklist

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.