### PR TITLE
Version 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [2.11.1]
+- BugFix[`BarLifeComponent`]: resolve bug offset when `drawPosition` equals `BarLifePorition.bottom`.
+
 # [2.11.0]
 - Render transform improvements.
 - BREAKING CHANGE: Now the `SimpleDirectionAnimation` do flip component that use it as necessary.

--- a/lib/util/barlife_component.dart
+++ b/lib/util/barlife_component.dart
@@ -86,7 +86,7 @@ class BarLifeComponent extends GameComponent with Follower {
     double xPosition = (followerTarget!.width - width) / 2 + x;
 
     if (drawPosition == BarLifePorition.bottom) {
-      yPosition = followerTarget!.bottom + margin;
+      yPosition = followerTarget!.bottom + (followerOffset?.y ?? 0.0) + margin;
     }
 
     yPosition = yPosition;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bonfire
 description: (RPG maker) Create RPG-style or similar games more simply with Flame.
-version: 2.11.0
+version: 2.11.1
 homepage: https://github.com/RafaelBarbosatec/bonfire
 
 environment:


### PR DESCRIPTION
- BugFix[`BarLifeComponent`]: resolve bug offset when `drawPosition` equals `BarLifePorition.bottom`.