### PR TITLE
Sensor mixin adjust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [2.11.9]
+- Decrease `intervalCheck` in Sensor mixin
+
 # [2.11.8]
 - Fix bug in `moveOnlyMapArea`
 

--- a/lib/mixins/sensor.dart
+++ b/lib/mixins/sensor.dart
@@ -14,7 +14,7 @@ mixin Sensor<T extends GameComponent> on GameComponent {
   bool enabledSensor = true;
   List<GameComponent> _componentsInContact = [];
 
-  int _intervalCheckContact = 250;
+  int _intervalCheck = 50;
   bool _checkOnlyVisible = true;
   final String _intervalCheckContactKey = 'KEY_CHECK_SENSOR_CONTACT';
 
@@ -36,11 +36,11 @@ mixin Sensor<T extends GameComponent> on GameComponent {
 
   void setupSensorArea({
     List<CollisionArea>? areaSensor,
-    int intervalCheck = 250,
+    int intervalCheck = 50,
     bool checkOnlyVisible = true,
   }) {
     _checkOnlyVisible = checkOnlyVisible;
-    _intervalCheckContact = intervalCheck;
+    _intervalCheck = intervalCheck;
     _collisionConfig = CollisionConfig(
       collisions: areaSensor ?? _sensorArea,
     );
@@ -49,7 +49,7 @@ mixin Sensor<T extends GameComponent> on GameComponent {
   @override
   void update(double dt) {
     if (enabledSensor && (_checkOnlyVisible ? isVisible : true)) {
-      if (checkInterval(_intervalCheckContactKey, _intervalCheckContact, dt)) {
+      if (checkInterval(_intervalCheckContactKey, _intervalCheck, dt)) {
         _collisionConfig ??= CollisionConfig(collisions: _sensorArea);
         _collisionConfig?.updatePosition(position);
         _verifyContact();


### PR DESCRIPTION
# Description

This PR decreases `intervalCheck` in Sensor mixin from 250 to 50 due collisions being ignored sometimes (yellow=250, red=50):

https://user-images.githubusercontent.com/36611739/206071446-60b569a5-5584-4bc3-9ab2-dfc913e42b44.mp4




## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I open this PR to the `develop` branch.
- [X] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [X] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [X] No, this is *not* a breaking change.