### PR TITLE
fix: Add mustCallSuper to GameComponent.update and onRemove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [Next]
+- Add mustCallSuper to GameComponent.update and GameComponent.onRemove
+
 # [2.11.11]
 - Fix [#261](https://github.com/RafaelBarbosatec/bonfire/issues/261)
 - Fix [#364](https://github.com/RafaelBarbosatec/bonfire/issues/364)

--- a/lib/base/game_component.dart
+++ b/lib/base/game_component.dart
@@ -47,6 +47,7 @@ abstract class GameComponent extends PositionComponent
   }
 
   @override
+  @mustCallSuper
   void update(double dt) {
     super.update(dt);
     _checkIsVisible(dt);
@@ -115,6 +116,7 @@ abstract class GameComponent extends PositionComponent
   }
 
   @override
+  @mustCallSuper
   void onRemove() {
     (gameRef as BonfireGame).removeVisible(this);
     super.onRemove();


### PR DESCRIPTION
# Description

Someone was confused why there code wasn't working on the discord and it was due to that they had forgotten to call `super.update`, this should make their IDE's warn them when they don't.

## Checklist

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.