### PR TITLE
It solve linter warnings issues on project

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,9 @@ Before you create this PR confirm that it meets all requirements listed below by
 
 - [ ] I open this PR to the `develop` branch.
 - [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
-- [ ] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.
+- [ ] I ran `dart format --set-exit-if-changed .` and has success.
+- [ ] I ran `flutter analyze` and has success.
+- [ ] I ran `flutter test` and has success.
 
 ## Breaking Change
 

--- a/lib/util/ambiguate.dart
+++ b/lib/util/ambiguate.dart
@@ -1,0 +1,21 @@
+/// This is a temporary solution to solve warnings issues,
+/// until we can migrate to Flutter 3.7. completely.
+///
+/// This allows a value of type T or T?
+/// to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become
+/// non-nullable can still be used with `!` and `?`
+/// to support older versions of the API as well.
+///
+/// Note: `Overlay.of(context)` is non-nullable in Flutter 3.7
+/// but it is in previous versions.
+///
+/// In all cases, we can ensures that `overlayState` will be of type `OverlayState?`.
+///
+/// e.g.
+/// ```dart
+///   var overlayState = ambiguate(Overlay.of(context));
+///   // overlayState is OverlayState? in all versions of Flutter
+/// ```
+T? ambiguate<T>(T? value) => value;

--- a/lib/util/extensions/extensions.dart
+++ b/lib/util/extensions/extensions.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart' as widget;
 export 'ally/ally_extensions.dart';
 export 'attackable_extensions.dart';
 export 'enemy/enemy_extensions.dart';
-export 'enemy/enemy_extensions.dart';
 export 'enemy/rotation_enemy_extensions.dart';
 export 'game_component_extensions.dart';
 export 'joystick_extensions.dart';

--- a/lib/util/follower_widget.dart
+++ b/lib/util/follower_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:async' as async;
 
 import 'package:bonfire/bonfire.dart';
+import 'package:bonfire/util/ambiguate.dart';
 import 'package:flutter/widgets.dart';
 
 ///
@@ -47,7 +48,7 @@ class FollowerWidget extends StatefulWidget {
       },
     );
 
-    Overlay.of(context)?.let((over) {
+    ambiguate(Overlay.of(context))?.let((over) {
       over.insert(overlay);
       _mapOverlayEntry[identify] = overlay;
     });

--- a/test/util/ambiguate_test.dart
+++ b/test/util/ambiguate_test.dart
@@ -1,0 +1,20 @@
+import 'package:bonfire/util/ambiguate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+      'Given a nullable or non-nullable value, when ambiguate is called, then the result is always nullable',
+      () {
+    // arrange
+    String nonNullable = 'nonNullable';
+    String? nullable;
+
+    // act
+    final nonNullableAsNullable = ambiguate(nonNullable);
+    final nullableAsNullable = ambiguate(nullable);
+
+    // assert
+    expect(nonNullableAsNullable, isA<String?>()); // String Nullable
+    expect(nullableAsNullable, isA<String?>()); // String Nullable
+  });
+}


### PR DESCRIPTION
# Description

- Fix warnings when run `flutter analyze` on Flutter version 3.7 (see screenshot)
- Fix duplicated imports on `extensions.dart` file
- Adds two new checklist item [`flutter test` and `flutter analyze`]
- On `pull_request_template.md`, changed `flutter format` to `dart format` since `flutter format` now is deprecated and will be removed in the future
- It creates `ambiguate` utility, in order to keep backward compatibility with old Flutter versions, avoiding linter warnings issues

<img width="824" alt="image" src="https://user-images.githubusercontent.com/3827308/216826494-f427bbe0-c560-4292-803f-2d10f9ee9c01.png">


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.