### PR TITLE
Fix collision & animation computation when a tileset use individual tiles definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [Next]
+- Fix issue [417](https://github.com/RafaelBarbosatec/bonfire/issues/417)
+
 # [2.12.6]
 - Adds fixed Flame version to `1.7.3`
 - Update Flutter sdk range `<4.0.0`

--- a/lib/tiled/builder/tiled_world_builder.dart
+++ b/lib/tiled/builder/tiled_world_builder.dart
@@ -289,6 +289,7 @@ class TiledWorldBuilder {
     String pathTileset = '';
     String imagePath = '';
     int firsTgId = 0;
+    int tilesetFirsTgId = 0;
     int widthCount = 1;
     Vector2 spriteSize = Vector2.all(0);
 
@@ -298,6 +299,7 @@ class TiledWorldBuilder {
       });
 
       firsTgId = tileSetContain?.firsTgId ?? 0;
+      tilesetFirsTgId = firsTgId;
       imagePath = tileSetContain?.image ?? '';
       widthCount =
           (tileSetContain?.imageWidth ?? 0) ~/ (tileSetContain?.tileWidth ?? 1);
@@ -353,13 +355,13 @@ class TiledWorldBuilder {
       final animation = _getAnimation(
         tileSetContain,
         pathTileset,
-        (index - firsTgId),
+        (index - tilesetFirsTgId),
         widthCount,
       );
 
       final object = _getCollision(
         tileSetContain,
-        (index - firsTgId),
+        (index - tilesetFirsTgId),
       );
 
       return TiledItemTileSet(


### PR DESCRIPTION
# Description

Fix the issue described in [417](https://github.com/RafaelBarbosatec/bonfire/issues/417) about collision computation in tileset when we use individual tiles definition

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.