### PR TITLE
Version 3.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Next
+- Create mixin `MovePerCell`.
+
 ## 3.0.9
 - adds new Pushable configurations. (`pushableFrom`,`pushPerCellEnabled`,`cellSize`,`pushPerCellDuration`,`pushPerCellCurve`)
 - adds method `List<Vector2> getPathToPosition` in mixin `PathFinding`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## Next
+## 3.0.10
 - Create mixin `MovePerCell`.
+- Create mixin `CanNotSeen`. Use it to turn your component not detectable from `Vision` mixin.
+- Update `showDamage` method.`initVelocityUp` renamed to `initVelocityVertical` and adds param `initVelocityHorizontal`.
+- Fix issue [#455](https://github.com/RafaelBarbosatec/bonfire/issues/455)
+- Fix bug [#474](https://github.com/RafaelBarbosatec/bonfire/issues/474)
 
 ## 3.0.9
 - adds new Pushable configurations. (`pushableFrom`,`pushPerCellEnabled`,`cellSize`,`pushPerCellDuration`,`pushPerCellCurve`)

--- a/example/lib/shared/decoration/potion_life.dart
+++ b/example/lib/shared/decoration/potion_life.dart
@@ -31,7 +31,7 @@ class PotionLife extends GameDecoration with Sensor<Player>, Movement {
 
   @override
   void onMount() {
-    generateValues(
+    gameRef.generateValues(
       const Duration(seconds: 1),
       onChange: (value) {
         spriteOffset = Vector2(0, 5 * -value);

--- a/lib/base/bonfire_game.dart
+++ b/lib/base/bonfire_game.dart
@@ -418,6 +418,34 @@ class BonfireGame extends BaseGame implements BonfireGameInterface {
     );
   }
 
+  /// Used to generate numbers to create your animations or anythings
+  @override
+  ValueGeneratorComponent generateValues(
+    Duration duration, {
+    double begin = 0.0,
+    double end = 1.0,
+    Curve curve = Curves.linear,
+    Curve? reverseCurve,
+    bool autoStart = true,
+    bool infinite = false,
+    VoidCallback? onFinish,
+    ValueChanged<double>? onChange,
+  }) {
+    final valueGenerator = ValueGeneratorComponent(
+      duration,
+      end: end,
+      begin: begin,
+      curve: curve,
+      reverseCurve: reverseCurve,
+      onFinish: onFinish,
+      onChange: onChange,
+      autoStart: autoStart,
+      infinite: infinite,
+    );
+    add(valueGenerator);
+    return valueGenerator;
+  }
+
   void _optimizeCollisionTree() {
     scheduleMicrotask(
       () => collisionDetection.broadphase.tree.optimize(),

--- a/lib/base/bonfire_game_interface.dart
+++ b/lib/base/bonfire_game_interface.dart
@@ -136,6 +136,19 @@ abstract class BonfireGameInterface {
     List<RaycastResult<ShapeHitbox>>? out,
   });
 
+  /// Used to generate numbers to create your animations or anythings
+  ValueGeneratorComponent generateValues(
+    Duration duration, {
+    double begin = 0.0,
+    double end = 1.0,
+    Curve curve = Curves.linear,
+    Curve? reverseCurve,
+    bool autoStart = true,
+    bool infinite = false,
+    VoidCallback? onFinish,
+    ValueChanged<double>? onChange,
+  });
+
   void startScene(List<SceneAction> actions, {void Function()? onComplete});
   void stopScene();
 

--- a/lib/bonfire.dart
+++ b/lib/bonfire.dart
@@ -46,6 +46,7 @@ export 'package:bonfire/mixins/use_barlife.dart';
 export 'package:bonfire/mixins/use_sprite.dart';
 export 'package:bonfire/mixins/use_sprite_animation.dart';
 export 'package:bonfire/mixins/vision.dart';
+export 'package:bonfire/mixins/move_per_cell.dart';
 export 'package:bonfire/npc/ally/ally.dart';
 export 'package:bonfire/npc/enemy/enemy.dart';
 export 'package:bonfire/npc/npc.dart';

--- a/lib/mixins/move_per_cell.dart
+++ b/lib/mixins/move_per_cell.dart
@@ -1,0 +1,171 @@
+import 'package:bonfire/bonfire.dart';
+import 'package:flutter/widgets.dart';
+
+mixin MovePerCell on Movement {
+  bool _pushPerCellEnabled = false;
+  double _pushPerCellDuration = 0.5;
+  Curve _pushPerCellCurve = Curves.decelerate;
+  Vector2? _cellSize;
+  bool _perCellEnabled = true;
+  bool _perCellMoving = false;
+
+  void setupMovePerCell({
+    bool? enabled,
+    PushableFromEnum? pushableFrom,
+    bool? pushPerCellEnabled,
+    Vector2? cellSize,
+    double? pushPerCellDuration,
+    Curve? pushPerCellCurve,
+  }) {
+    _perCellEnabled = enabled ?? _perCellEnabled;
+    _pushPerCellEnabled = pushPerCellEnabled ?? _pushPerCellEnabled;
+    _cellSize = cellSize ?? _cellSize;
+    _pushPerCellDuration = pushPerCellDuration ?? _pushPerCellDuration;
+    _pushPerCellCurve = pushPerCellCurve ?? _pushPerCellCurve;
+  }
+
+  Vector2 get cellSize => _cellSize ?? size;
+
+  @override
+  void moveLeft({double? speed}) {
+    if (_perCellEnabled) {
+      if (_perCellMoving) return;
+      _perCellMoving = true;
+      add(
+        MoveEffect.by(
+          Vector2(-cellSize.x, 0),
+          EffectController(
+            duration: _pushPerCellDuration,
+            curve: _pushPerCellCurve,
+          ),
+          onComplete: _perCeelMovecomplete,
+        ),
+      );
+    } else {
+      super.moveLeft(speed: speed);
+    }
+  }
+
+  @override
+  void moveRight({double? speed}) {
+    if (_perCellEnabled) {
+      if (_perCellMoving) return;
+      _perCellMoving = true;
+      add(
+        MoveEffect.by(
+          Vector2(cellSize.x, 0),
+          EffectController(
+            duration: _pushPerCellDuration,
+            curve: _pushPerCellCurve,
+          ),
+          onComplete: _perCeelMovecomplete,
+        ),
+      );
+    } else {
+      super.moveRight(speed: speed);
+    }
+  }
+
+  @override
+  void moveDown({double? speed}) {
+    if (_perCellEnabled) {
+      if (_perCellMoving) return;
+      _perCellMoving = true;
+      add(
+        MoveEffect.by(
+          Vector2(0, cellSize.x),
+          EffectController(
+            duration: _pushPerCellDuration,
+            curve: _pushPerCellCurve,
+          ),
+          onComplete: _perCeelMovecomplete,
+        ),
+      );
+    } else {
+      super.moveDown(speed: speed);
+    }
+  }
+
+  @override
+  void moveUp({double? speed}) {
+    if (_perCellEnabled) {
+      if (_perCellMoving) return;
+      _perCellMoving = true;
+      add(
+        MoveEffect.by(
+          Vector2(0, -cellSize.x),
+          EffectController(
+            duration: _pushPerCellDuration,
+            curve: _pushPerCellCurve,
+          ),
+          onComplete: _perCeelMovecomplete,
+        ),
+      );
+    } else {
+      super.moveUp(speed: speed);
+    }
+  }
+
+  @override
+  void moveDownLeft({double? speed}) {
+    if (!_perCellEnabled) {
+      super.moveDownLeft(speed: speed);
+    } else {
+      stopMove();
+    }
+  }
+
+  @override
+  void moveDownRight({double? speed}) {
+    if (!_perCellEnabled) {
+      super.moveDownRight(speed: speed);
+    } else {
+      stopMove();
+    }
+  }
+
+  @override
+  void moveUpRight({double? speed}) {
+    if (!_perCellEnabled) {
+      super.moveUpRight(speed: speed);
+    } else {
+      stopMove();
+    }
+  }
+
+  @override
+  void moveUpLeft({double? speed}) {
+    if (!_perCellEnabled) {
+      super.moveUpLeft(speed: speed);
+    } else {
+      stopMove();
+    }
+  }
+
+  @override
+  void moveFromAngle(double angle, {double? speed}) {
+    if (_perCellEnabled) {
+      switch (BonfireUtil.getDirectionFromAngle(angle, directionSpace: 45)) {
+        case Direction.left:
+          moveLeft();
+          break;
+        case Direction.right:
+          moveRight();
+          break;
+        case Direction.up:
+          moveUp();
+          break;
+        case Direction.down:
+          moveDown();
+          break;
+        default:
+      }
+    } else {
+      super.moveFromAngle(angle, speed: speed);
+    }
+  }
+
+  void _perCeelMovecomplete() {
+    _perCellMoving = false;
+  }
+}

--- a/lib/mixins/vision.dart
+++ b/lib/mixins/vision.dart
@@ -220,4 +220,5 @@ mixin Vision on GameComponent {
   }
 }
 
+// Use it to turn your component not detectable from `Vision` mixin.
 mixin CanNotSeen on GameComponent {}

--- a/lib/mixins/vision.dart
+++ b/lib/mixins/vision.dart
@@ -61,7 +61,7 @@ mixin Vision on GameComponent {
     GameComponent component,
     double radiusVision,
   ) {
-    if (component.isRemoving) {
+    if (component.isRemoving || component is CanNotSeen) {
       return false;
     }
 
@@ -82,6 +82,7 @@ mixin Vision on GameComponent {
           direction,
           maxDistance: radiusVision,
           origin: myCenter,
+          ignoreHitboxes: _getCanNotSeenHitbox(),
         );
         return result?.hitbox?.parent == component;
       }
@@ -209,4 +210,14 @@ mixin Vision on GameComponent {
     }
     return shape;
   }
+
+  List<ShapeHitbox> _getCanNotSeenHitbox() {
+    var sensorHitBox = <ShapeHitbox>[];
+    gameRef.query<CanNotSeen>(onlyVisible: true).forEach((e) {
+      sensorHitBox.addAll(e.children.query<ShapeHitbox>());
+    });
+    return sensorHitBox;
+  }
 }
+
+mixin CanNotSeen on GameComponent {}

--- a/lib/objects/flying_attack_game_object.dart
+++ b/lib/objects/flying_attack_game_object.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 
 /// Animated component used like range attack.
 class FlyingAttackGameObject extends AnimatedGameObject
-    with Movement, BlockMovementCollision {
+    with Movement, BlockMovementCollision, CanNotSeen {
   final dynamic id;
   Future<SpriteAnimation>? animationDestroy;
   final Direction? direction;

--- a/lib/util/extensions/game_component_extensions.dart
+++ b/lib/util/extensions/game_component_extensions.dart
@@ -8,7 +8,8 @@ extension GameComponentExtensions on GameComponent {
   void showDamage(
     double damage, {
     TextStyle? config,
-    double initVelocityUp = -5,
+    double initVelocityVertical = -5,
+    double initVelocityHorizontal = 1,
     double gravity = 0.5,
     double maxDownSize = 20,
     DirectionTextDamage direction = DirectionTextDamage.RANDOM,
@@ -24,7 +25,8 @@ extension GameComponentExtensions on GameComponent {
               fontSize: 14,
               color: Color(0xFFFFFFFF),
             ),
-        initVelocityUp: initVelocityUp,
+        initVelocityVertical: initVelocityVertical,
+        initVelocityHorizontal: initVelocityHorizontal,
         gravity: gravity,
         direction: direction,
         onlyUp: onlyUp,

--- a/lib/util/text_damage_component.dart
+++ b/lib/util/text_damage_component.dart
@@ -25,7 +25,8 @@ class TextDamageComponent extends TextComponent with BonfireHasGameRef {
     Vector2 position, {
     this.onlyUp = false,
     TextStyle? config,
-    double initVelocityUp = -4,
+    double initVelocityVertical = -4,
+    double initVelocityHorizontal = 1,
     this.maxDownSize = 20,
     this.gravity = 0.5,
     this.direction = DirectionTextDamage.RANDOM,
@@ -37,16 +38,17 @@ class TextDamageComponent extends TextComponent with BonfireHasGameRef {
           position: position,
         ) {
     _initialY = position.y;
-    _velocity = initVelocityUp;
+    _velocity = initVelocityVertical;
     switch (direction) {
       case DirectionTextDamage.LEFT:
-        _moveAxisX = 1;
+        _moveAxisX = initVelocityHorizontal;
         break;
       case DirectionTextDamage.RIGHT:
-        _moveAxisX = -1;
+        _moveAxisX = initVelocityHorizontal * -1;
         break;
       case DirectionTextDamage.RANDOM:
-        _moveAxisX = Random().nextInt(100) % 2 == 0 ? -1 : 1;
+        _moveAxisX =
+            initVelocityHorizontal * Random().nextInt(100) % 2 == 0 ? -1 : 1;
         break;
       case DirectionTextDamage.NONE:
         break;
@@ -70,8 +72,15 @@ class TextDamageComponent extends TextComponent with BonfireHasGameRef {
     if (onlyUp && _velocity >= 0) {
       removeFromParent();
     }
-    if (position.y > _initialY + maxDownSize) {
-      removeFromParent();
+
+    if (gravity > 0) {
+      if (position.y > _initialY + maxDownSize) {
+        removeFromParent();
+      }
+    } else if (gravity < 0) {
+      if (position.y < _initialY - maxDownSize) {
+        removeFromParent();
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bonfire
 description: (RPG maker) Create RPG-style or similar games more simply with Flame.
-version: 3.0.9
+version: 3.0.10
 homepage: https://bonfire-engine.github.io
 repository: https://github.com/RafaelBarbosatec/bonfire
 issue_tracker: https://github.com/RafaelBarbosatec/bonfire/issues


### PR DESCRIPTION
- Create mixin `MovePerCell`.
- Create mixin `CanNotSeen`. Use it to turn your component not detectable from `Vision` mixin.
- Update `showDamage` method.`initVelocityUp` renamed to `initVelocityVertical` and adds param `initVelocityHorizontal`.
- Fix issue [#455](https://github.com/RafaelBarbosatec/bonfire/issues/455)
- Fix bug [#474](https://github.com/RafaelBarbosatec/bonfire/issues/474)