### PR TITLE
Version 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# Next
+- `JoystickDirectional` improvements. Now you can use `Alignment`.
+- `JoystickAction` improvements. Now you can use `Alignment`.
+- Adds param `PlayerControllerListener? observer` in `Joyctick`. If pass this param. the joystic will controll this observer and not the Component passed in `player` param.
+- Adds param `PlayerControllerListener? observer` in `Keyboard`. If pass this param. the keyboard will controll this observer and not the Component passed in `player` param.
+Breaking Change:
+  - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this, now is possible pass multi ways to controll de player or any component that contains the mixins `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.
+  - Remove `keyboardConfig` param from `BonfireWidget`. Now pass `Keyboard` instance in `playerControllers`.
+  Example using joystick and keyboad:
+  ```dart
+    return BonfireWidget(
+      map: ...,
+      playerControllers: [
+        Joystick(directional: JoystickDirectional()),
+        Keyboard(),
+      ],
+      player: HumanPlayer(
+        position: Vector2(100, 100),
+      ),
+    );
+  ```
+
 # 3.8.7
 - Fix bug collision. [#511](https://github.com/RafaelBarbosatec/bonfire/issues/511)
 - Renamed `AutomaticRandomMovement` to `RandomMovement`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `JoystickAction` improvements. Now you can use `Alignment`.
 - Adds param `PlayerControllerListener? observer` in `Joystick`. If pass this param, the joystick will controll this observer and not the Component passed in `player` param.
 - Adds param `PlayerControllerListener? observer` in `Keyboard`. If pass this param, the keyboard will controll this observer and not the Component passed in `player` param.
+- Fix type `BarLifeDrawPosition`. [#515](https://github.com/RafaelBarbosatec/bonfire/issues/515)
 
 **Breaking Changes:**
   - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this improvements is possible pass multi ways to control de player or any component that contains the mixin `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # 3.9.0
 - `JoystickDirectional` improvements. Now you can use `Alignment`.
 - `JoystickAction` improvements. Now you can use `Alignment`.
-- Adds param `PlayerControllerListener? observer` in `Joyctick`. If pass this param, the joystick will controll this observer and not the Component passed in `player` param.
+- Adds param `PlayerControllerListener? observer` in `Joystick`. If pass this param, the joystick will controll this observer and not the Component passed in `player` param.
 - Adds param `PlayerControllerListener? observer` in `Keyboard`. If pass this param, the keyboard will controll this observer and not the Component passed in `player` param.
 
 **Breaking Changes:**
-  - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this improvements is possible pass multi ways to controll de player or any component that contains the mixins `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.
+  - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this improvements is possible pass multi ways to control de player or any component that contains the mixin `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.
   - Removed `keyboardConfig` param from `BonfireWidget`. Now pass `Keyboard` instance in `playerControllers`.
-  Example using joystick and keyboad:
+  Example using joystick and keyboard:
   ```dart
     return BonfireWidget(
       map: ...,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 3.9.0
 - `JoystickDirectional` improvements. Now you can use `Alignment`.
 - `JoystickAction` improvements. Now you can use `Alignment`.
 - Adds param `PlayerControllerListener? observer` in `Joyctick`. If pass this param, the joystick will controll this observer and not the Component passed in `player` param.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 - `JoystickAction` improvements. Now you can use `Alignment`.
 - Adds param `PlayerControllerListener? observer` in `Joyctick`. If pass this param, the joystick will controll this observer and not the Component passed in `player` param.
 - Adds param `PlayerControllerListener? observer` in `Keyboard`. If pass this param, the keyboard will controll this observer and not the Component passed in `player` param.
-Breaking Change:
-  - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this, now is possible pass multi ways to controll de player or any component that contains the mixins `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.
-  - Remove `keyboardConfig` param from `BonfireWidget`. Now pass `Keyboard` instance in `playerControllers`.
+
+**Breaking Changes:**
+  - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this improvements is possible pass multi ways to controll de player or any component that contains the mixins `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.
+  - Removed `keyboardConfig` param from `BonfireWidget`. Now pass `Keyboard` instance in `playerControllers`.
   Example using joystick and keyboad:
   ```dart
     return BonfireWidget(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Next
 - `JoystickDirectional` improvements. Now you can use `Alignment`.
 - `JoystickAction` improvements. Now you can use `Alignment`.
-- Adds param `PlayerControllerListener? observer` in `Joyctick`. If pass this param. the joystic will controll this observer and not the Component passed in `player` param.
-- Adds param `PlayerControllerListener? observer` in `Keyboard`. If pass this param. the keyboard will controll this observer and not the Component passed in `player` param.
+- Adds param `PlayerControllerListener? observer` in `Joyctick`. If pass this param, the joystick will controll this observer and not the Component passed in `player` param.
+- Adds param `PlayerControllerListener? observer` in `Keyboard`. If pass this param, the keyboard will controll this observer and not the Component passed in `player` param.
 Breaking Change:
   - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this, now is possible pass multi ways to controll de player or any component that contains the mixins `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.
   - Remove `keyboardConfig` param from `BonfireWidget`. Now pass `Keyboard` instance in `playerControllers`.

--- a/example/lib/pages/enemy/enemy_page.dart
+++ b/example/lib/pages/enemy/enemy_page.dart
@@ -18,9 +18,11 @@ class EnemyPage extends StatelessWidget {
           'melee': (properties) => MeleeEnemy(position: properties.position),
         },
       ),
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        )
+      ],
       player: HumanPlayer(
         position: Vector2(tileSize * 7, tileSize * 8),
       ),

--- a/example/lib/pages/home/home_page.dart
+++ b/example/lib/pages/home/home_page.dart
@@ -30,6 +30,8 @@ import 'package:example/pages/player/simple/simple_player_page.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../player_controllers/player_controllers_page.dart';
+
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
 
@@ -171,6 +173,12 @@ class _HomePageState extends State<HomePage> {
             builder: (_) => const KeyboardPage(),
             codeUrl:
                 'https://github.com/RafaelBarbosatec/bonfire/blob/develop/example/lib/pages/input/keyboard',
+          ),
+          ItemDrawer(
+            name: 'PlayerControllers',
+            builder: (_) => const PlayerControllersPage(),
+            codeUrl:
+                'https://github.com/RafaelBarbosatec/bonfire/blob/develop/example/lib/pages/player_controllers',
           ),
         ],
       ),

--- a/example/lib/pages/home/home_page.dart
+++ b/example/lib/pages/home/home_page.dart
@@ -76,7 +76,7 @@ class _HomePageState extends State<HomePage> {
                 child: ElevatedButton(
                   onPressed: () => _launch(itemSelected!.codeUrl),
                   style: const ButtonStyle(
-                    shape: MaterialStatePropertyAll(
+                    shape: WidgetStatePropertyAll(
                       RoundedRectangleBorder(
                         borderRadius: BorderRadius.all(Radius.circular(20)),
                       ),

--- a/example/lib/pages/map/spritefusion/spritefusion_page.dart
+++ b/example/lib/pages/map/spritefusion/spritefusion_page.dart
@@ -8,7 +8,11 @@ class SpritefusionPage extends StatelessWidget {
   Widget build(BuildContext context) {
     const tileSize = 16.0;
     return BonfireWidget(
-      joystick: Joystick(directional: JoystickDirectional()),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        )
+      ],
       map: WorldMapBySpritefusion(
         WorldMapReader.fromAsset('spritefusion/map.json'),
       ),

--- a/example/lib/pages/map/terrain_builder/terrain_builder_page.dart
+++ b/example/lib/pages/map/terrain_builder/terrain_builder_page.dart
@@ -13,7 +13,11 @@ class TerrainBuilderPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(directional: JoystickDirectional()),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        )
+      ],
       map: MatrixMapGenerator.generate(
         layers: [
           MatrixLayer(

--- a/example/lib/pages/map/tiled/tiled_network_page.dart
+++ b/example/lib/pages/map/tiled/tiled_network_page.dart
@@ -42,7 +42,11 @@ class _TiledNetworkPageState extends State<TiledNetworkPage>
           FadeTransition(
             opacity: _controller,
             child: BonfireWidget(
-              joystick: Joystick(directional: JoystickDirectional()),
+              playerControllers: [
+                Joystick(
+                  directional: JoystickDirectional(),
+                )
+              ],
               map: WorldMapByTiled(
                 WorldMapReader.fromNetwork(
                   Uri.parse(

--- a/example/lib/pages/map/tiled/tiled_page.dart
+++ b/example/lib/pages/map/tiled/tiled_page.dart
@@ -9,7 +9,11 @@ class TiledPage extends StatelessWidget {
   Widget build(BuildContext context) {
     const tileSize = 16.0;
     return BonfireWidget(
-      joystick: Joystick(directional: JoystickDirectional()),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        )
+      ],
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('tiled/tiled_example.tmj'),
         objectsBuilder: {

--- a/example/lib/pages/mini_games/lpc/lpc_game.dart
+++ b/example/lib/pages/mini_games/lpc/lpc_game.dart
@@ -25,9 +25,11 @@ class LPCGame extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        ),
+      ],
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('tiled/mapa2.json'),
         forceTileSize: Vector2(32, 32),

--- a/example/lib/pages/mini_games/manual_map/game_manual_map.dart
+++ b/example/lib/pages/mini_games/manual_map/game_manual_map.dart
@@ -26,7 +26,6 @@ class GameManualMap extends StatelessWidget {
               JoystickAction(
                 actionId: PlayerAttackType.attackMelee,
                 sprite: Sprite.load('joystick_attack.png'),
-                align: JoystickActionAlign.BOTTOM_RIGHT,
                 size: 80,
                 margin: const EdgeInsets.only(bottom: 50, right: 50),
               ),

--- a/example/lib/pages/mini_games/manual_map/game_manual_map.dart
+++ b/example/lib/pages/mini_games/manual_map/game_manual_map.dart
@@ -42,7 +42,7 @@ class GameManualMap extends StatelessWidget {
             ],
           ),
           Keyboard(
-            keyboardConfig: KeyboardConfig(
+            config: KeyboardConfig(
               acceptedKeys: [
                 LogicalKeyboardKey.space,
               ],

--- a/example/lib/pages/mini_games/manual_map/game_manual_map.dart
+++ b/example/lib/pages/mini_games/manual_map/game_manual_map.dart
@@ -13,36 +13,42 @@ class GameManualMap extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       return BonfireWidget(
-        joystick: Joystick(
-          directional: JoystickDirectional(
-            spriteBackgroundDirectional: Sprite.load('joystick_background.png'),
-            spriteKnobDirectional: Sprite.load('joystick_knob.png'),
-            size: 100,
-            isFixed: false,
-          ),
-          actions: [
-            JoystickAction(
-              actionId: PlayerAttackType.attackMelee,
-              sprite: Sprite.load('joystick_attack.png'),
-              align: JoystickActionAlign.BOTTOM_RIGHT,
-              size: 80,
-              margin: const EdgeInsets.only(bottom: 50, right: 50),
+        playerControllers: [
+          Joystick(
+            directional: JoystickDirectional(
+              spriteBackgroundDirectional:
+                  Sprite.load('joystick_background.png'),
+              spriteKnobDirectional: Sprite.load('joystick_knob.png'),
+              size: 100,
+              isFixed: false,
             ),
-            JoystickAction(
-              actionId: PlayerAttackType.attackRange,
-              sprite: Sprite.load('joystick_attack_range.png'),
-              spriteBackgroundDirection: Sprite.load('joystick_background.png'),
-              size: 50,
-              enableDirection: true,
-              margin: const EdgeInsets.only(bottom: 50, right: 160),
-            )
-          ],
-        ),
-        keyboardConfig: KeyboardConfig(
-          acceptedKeys: [
-            LogicalKeyboardKey.space,
-          ],
-        ),
+            actions: [
+              JoystickAction(
+                actionId: PlayerAttackType.attackMelee,
+                sprite: Sprite.load('joystick_attack.png'),
+                align: JoystickActionAlign.BOTTOM_RIGHT,
+                size: 80,
+                margin: const EdgeInsets.only(bottom: 50, right: 50),
+              ),
+              JoystickAction(
+                actionId: PlayerAttackType.attackRange,
+                sprite: Sprite.load('joystick_attack_range.png'),
+                spriteBackgroundDirection:
+                    Sprite.load('joystick_background.png'),
+                size: 50,
+                enableDirection: true,
+                margin: const EdgeInsets.only(bottom: 50, right: 160),
+              )
+            ],
+          ),
+          Keyboard(
+            keyboardConfig: KeyboardConfig(
+              acceptedKeys: [
+                LogicalKeyboardKey.space,
+              ],
+            ),
+          )
+        ],
         player: Knight(
           Vector2((4 * DungeonMap.tileSize), (6 * DungeonMap.tileSize)),
         ),

--- a/example/lib/pages/mini_games/multi_scenario/maps/map_biome_1.dart
+++ b/example/lib/pages/mini_games/multi_scenario/maps/map_biome_1.dart
@@ -17,9 +17,11 @@ class MapBiome1 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        ),
+      ],
       player: GamePlayer(
         _getInitPosition(),
         PirateSpriteSheet.getAnimation(),

--- a/example/lib/pages/mini_games/multi_scenario/maps/map_biome_2.dart
+++ b/example/lib/pages/mini_games/multi_scenario/maps/map_biome_2.dart
@@ -19,9 +19,11 @@ class MapBiome2 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        ),
+      ],
       player: GamePlayer(
         _getInitPosition(),
         PirateSpriteSheet.getAnimation(),

--- a/example/lib/pages/mini_games/platform/platform_game.dart
+++ b/example/lib/pages/mini_games/platform/platform_game.dart
@@ -30,23 +30,27 @@ class _PlatformGameState extends State<PlatformGame> {
               ),
         },
       ),
-      keyboardConfig: KeyboardConfig(
-        acceptedKeys: [
-          LogicalKeyboardKey.space,
-        ],
-      ),
-      joystick: Joystick(
-        directional: JoystickDirectional(
-          color: Colors.green,
-        ),
-        actions: [
-          JoystickAction(
-            actionId: 1,
-            margin: const EdgeInsets.all(50),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(
             color: Colors.green,
           ),
-        ],
-      ),
+          actions: [
+            JoystickAction(
+              actionId: 1,
+              margin: const EdgeInsets.all(50),
+              color: Colors.green,
+            ),
+          ],
+        ),
+        Keyboard(
+          keyboardConfig: KeyboardConfig(
+            acceptedKeys: [
+              LogicalKeyboardKey.space,
+            ],
+          ),
+        ),
+      ],
       components: [PlatformGameController(reset: reset)],
       backgroundColor: const Color(0xFF2fbdff),
       globalForces: [

--- a/example/lib/pages/mini_games/platform/platform_game.dart
+++ b/example/lib/pages/mini_games/platform/platform_game.dart
@@ -44,7 +44,7 @@ class _PlatformGameState extends State<PlatformGame> {
           ],
         ),
         Keyboard(
-          keyboardConfig: KeyboardConfig(
+          config: KeyboardConfig(
             acceptedKeys: [
               LogicalKeyboardKey.space,
             ],

--- a/example/lib/pages/mini_games/random_map/random_map_game.dart
+++ b/example/lib/pages/mini_games/random_map/random_map_game.dart
@@ -52,12 +52,14 @@ class _RandomMapGameState extends State<RandomMapGame> {
         }
         MapGenerated result = snapshot.data!;
         return BonfireWidget(
-          joystick: Joystick(
-            directional: JoystickDirectional(
-              size: 100,
-              isFixed: false,
+          playerControllers: [
+            Joystick(
+              directional: JoystickDirectional(
+                size: 100,
+                isFixed: false,
+              ),
             ),
-          ),
+          ],
           player: result.player,
           cameraConfig: CameraConfig(
             moveOnlyMapArea: true,

--- a/example/lib/pages/mini_games/simple_example/simple_example_game.dart
+++ b/example/lib/pages/mini_games/simple_example/simple_example_game.dart
@@ -22,9 +22,11 @@ class SimpleExampleGame extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        ),
+      ],
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('tiled/mapa2.json'),
         forceTileSize: Vector2.all(32),

--- a/example/lib/pages/mini_games/tiled_map/game_tiled_map.dart
+++ b/example/lib/pages/mini_games/tiled_map/game_tiled_map.dart
@@ -57,7 +57,7 @@ class GameTiledMap extends StatelessWidget {
               ],
             ),
             Keyboard(
-              keyboardConfig: KeyboardConfig(
+              config: KeyboardConfig(
                 directionalKeys: [
                   KeyboardDirectionalKeys.arrows(),
                   KeyboardDirectionalKeys.wasd(),

--- a/example/lib/pages/mini_games/tiled_map/game_tiled_map.dart
+++ b/example/lib/pages/mini_games/tiled_map/game_tiled_map.dart
@@ -26,44 +26,48 @@ class GameTiledMap extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         return BonfireWidget(
-          keyboardConfig: KeyboardConfig(
-            directionalKeys: [
-              KeyboardDirectionalKeys.arrows(),
-              KeyboardDirectionalKeys.wasd(),
-            ],
-            acceptedKeys: [
-              LogicalKeyboardKey.space,
-            ],
-          ),
-          joystick: Joystick(
-            directional: JoystickDirectional(
-              spriteBackgroundDirectional: Sprite.load(
-                'joystick_background.png',
-              ),
-              spriteKnobDirectional: Sprite.load('joystick_knob.png'),
-              size: 100,
-              isFixed: false,
-            ),
-            actions: [
-              JoystickAction(
-                actionId: PlayerAttackType.attackMelee,
-                sprite: Sprite.load('joystick_attack.png'),
-                align: JoystickActionAlign.BOTTOM_RIGHT,
-                size: 80,
-                margin: const EdgeInsets.only(bottom: 50, right: 50),
-              ),
-              JoystickAction(
-                actionId: PlayerAttackType.attackRange,
-                sprite: Sprite.load('joystick_attack_range.png'),
-                spriteBackgroundDirection: Sprite.load(
+          playerControllers: [
+            Joystick(
+              directional: JoystickDirectional(
+                spriteBackgroundDirectional: Sprite.load(
                   'joystick_background.png',
                 ),
-                enableDirection: true,
-                size: 50,
-                margin: const EdgeInsets.only(bottom: 50, right: 160),
-              )
-            ],
-          ),
+                spriteKnobDirectional: Sprite.load('joystick_knob.png'),
+                size: 100,
+                isFixed: false,
+              ),
+              actions: [
+                JoystickAction(
+                  actionId: PlayerAttackType.attackMelee,
+                  sprite: Sprite.load('joystick_attack.png'),
+                  align: JoystickActionAlign.BOTTOM_RIGHT,
+                  size: 80,
+                  margin: const EdgeInsets.only(bottom: 50, right: 50),
+                ),
+                JoystickAction(
+                  actionId: PlayerAttackType.attackRange,
+                  sprite: Sprite.load('joystick_attack_range.png'),
+                  spriteBackgroundDirection: Sprite.load(
+                    'joystick_background.png',
+                  ),
+                  enableDirection: true,
+                  size: 50,
+                  margin: const EdgeInsets.only(bottom: 50, right: 160),
+                )
+              ],
+            ),
+            Keyboard(
+              keyboardConfig: KeyboardConfig(
+                directionalKeys: [
+                  KeyboardDirectionalKeys.arrows(),
+                  KeyboardDirectionalKeys.wasd(),
+                ],
+                acceptedKeys: [
+                  LogicalKeyboardKey.space,
+                ],
+              ),
+            )
+          ],
           player: Knight(
             Vector2((8 * DungeonMap.tileSize), (5 * DungeonMap.tileSize)),
           ),

--- a/example/lib/pages/mini_games/tiled_map/game_tiled_map.dart
+++ b/example/lib/pages/mini_games/tiled_map/game_tiled_map.dart
@@ -40,7 +40,6 @@ class GameTiledMap extends StatelessWidget {
                 JoystickAction(
                   actionId: PlayerAttackType.attackMelee,
                   sprite: Sprite.load('joystick_attack.png'),
-                  align: JoystickActionAlign.BOTTOM_RIGHT,
                   size: 80,
                   margin: const EdgeInsets.only(bottom: 50, right: 50),
                 ),

--- a/example/lib/pages/mini_games/top_down_game/top_down_game.dart
+++ b/example/lib/pages/mini_games/top_down_game/top_down_game.dart
@@ -29,15 +29,17 @@ class TopDownGame extends StatelessWidget {
           'armchair': (prop) => ArmchairDecoration(prop.position),
         },
       ),
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-        actions: [
-          JoystickAction(
-            actionId: 1,
-            margin: const EdgeInsets.all(50),
-          ),
-        ],
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+          actions: [
+            JoystickAction(
+              actionId: 1,
+              margin: const EdgeInsets.all(50),
+            ),
+          ],
+        ),
+      ],
       cameraConfig: CameraConfig(
         moveOnlyMapArea: true,
         zoom: getZoomFromMaxVisibleTile(context, 68, 12),

--- a/example/lib/pages/parallax/bonfire/bonfire_parallax_page.dart
+++ b/example/lib/pages/parallax/bonfire/bonfire_parallax_page.dart
@@ -9,15 +9,17 @@ class BonfireParallaxPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-        actions: [
-          JoystickAction(
-            actionId: 1,
-            margin: const EdgeInsets.all(50),
-          ),
-        ],
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+          actions: [
+            JoystickAction(
+              actionId: 1,
+              margin: const EdgeInsets.all(50),
+            ),
+          ],
+        )
+      ],
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('platform/parallax_map.tmj'),
       ),

--- a/example/lib/pages/parallax/bonfire/parallax_page.dart
+++ b/example/lib/pages/parallax/bonfire/parallax_page.dart
@@ -9,9 +9,11 @@ class ParallaxPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        )
+      ],
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('platform/parallax_map.tmj'),
       ),

--- a/example/lib/pages/parallax/flame/parallax_page.dart
+++ b/example/lib/pages/parallax/flame/parallax_page.dart
@@ -9,15 +9,17 @@ class ParallaxPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BonfireWidget(
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-        actions: [
-          JoystickAction(
-            actionId: 1,
-            margin: const EdgeInsets.all(50),
-          ),
-        ],
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+          actions: [
+            JoystickAction(
+              actionId: 1,
+              margin: const EdgeInsets.all(50),
+            ),
+          ],
+        ),
+      ],
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('platform/parallax_map.tmj'),
       ),

--- a/example/lib/pages/player/platform/platform_player_page.dart
+++ b/example/lib/pages/player/platform/platform_player_page.dart
@@ -13,20 +13,24 @@ class PlatformPlayerPage extends StatelessWidget {
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('platform/simple_map.tmj'),
       ),
-      keyboardConfig: KeyboardConfig(
-        acceptedKeys: [
-          LogicalKeyboardKey.space,
-        ],
-      ),
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-        actions: [
-          JoystickAction(
-            actionId: 1,
-            margin: const EdgeInsets.all(50),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+          actions: [
+            JoystickAction(
+              actionId: 1,
+              margin: const EdgeInsets.all(50),
+            ),
+          ],
+        ),
+        Keyboard(
+          keyboardConfig: KeyboardConfig(
+            acceptedKeys: [
+              LogicalKeyboardKey.space,
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
       player: SimpleFoxPlayer(
         position: Vector2(tileSize * 7, tileSize * 3),
       ),

--- a/example/lib/pages/player/platform/platform_player_page.dart
+++ b/example/lib/pages/player/platform/platform_player_page.dart
@@ -24,7 +24,7 @@ class PlatformPlayerPage extends StatelessWidget {
           ],
         ),
         Keyboard(
-          keyboardConfig: KeyboardConfig(
+          config: KeyboardConfig(
             acceptedKeys: [
               LogicalKeyboardKey.space,
             ],

--- a/example/lib/pages/player/rotation/rotation_player_page.dart
+++ b/example/lib/pages/player/rotation/rotation_player_page.dart
@@ -12,9 +12,11 @@ class RotationPlayerPage extends StatelessWidget {
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('tiled/simple_topdown/simple.tmj'),
       ),
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        )
+      ],
       player: HumanTopdownPlayer(
         position: Vector2(5 * tileSize, 5 * tileSize),
       ),

--- a/example/lib/pages/player/simple/simple_player_page.dart
+++ b/example/lib/pages/player/simple/simple_player_page.dart
@@ -12,9 +12,11 @@ class SimplePlayerPage extends StatelessWidget {
       map: WorldMapByTiled(
         WorldMapReader.fromAsset('tiled/punnyworld/simple_map.tmj'),
       ),
-      joystick: Joystick(
-        directional: JoystickDirectional(),
-      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(),
+        )
+      ],
       player: HumanPlayer(
         position: Vector2(tileSize * 7, tileSize * 6),
       ),

--- a/example/lib/pages/player/simple/simple_player_page.dart
+++ b/example/lib/pages/player/simple/simple_player_page.dart
@@ -13,9 +13,7 @@ class SimplePlayerPage extends StatelessWidget {
         WorldMapReader.fromAsset('tiled/punnyworld/simple_map.tmj'),
       ),
       playerControllers: [
-        Joystick(
-          directional: JoystickDirectional(),
-        ),
+        Joystick(directional: JoystickDirectional()),
         Keyboard(),
       ],
       player: HumanPlayer(

--- a/example/lib/pages/player/simple/simple_player_page.dart
+++ b/example/lib/pages/player/simple/simple_player_page.dart
@@ -15,7 +15,8 @@ class SimplePlayerPage extends StatelessWidget {
       playerControllers: [
         Joystick(
           directional: JoystickDirectional(),
-        )
+        ),
+        Keyboard(),
       ],
       player: HumanPlayer(
         position: Vector2(tileSize * 7, tileSize * 6),

--- a/example/lib/pages/player_controllers/player_controllers_page.dart
+++ b/example/lib/pages/player_controllers/player_controllers_page.dart
@@ -1,0 +1,69 @@
+import 'package:bonfire/bonfire.dart';
+import 'package:flutter/src/services/keyboard_key.g.dart';
+import 'package:flutter/widgets.dart';
+
+import '../player/simple/human.dart';
+
+class PlayerControllersPage extends StatelessWidget {
+  const PlayerControllersPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const tileSize = 16.0;
+    final secondPlayer = HumanPlayer(
+      position: Vector2(tileSize * 9, tileSize * 6),
+    );
+    return BonfireWidget(
+      map: WorldMapByTiled(
+        WorldMapReader.fromAsset('tiled/punnyworld/simple_map.tmj'),
+      ),
+      playerControllers: [
+        Joystick(
+          directional: JoystickDirectional(
+            alignment: Alignment.centerLeft,
+          ),
+        ),
+        Keyboard(
+          config: KeyboardConfig(
+            directionalKeys: [
+              KeyboardDirectionalKeys.arrows(),
+            ],
+          ),
+        ),
+        // Controlles of second player
+        Joystick(
+          directional: JoystickDirectional(alignment: Alignment.centerRight),
+          observer: secondPlayer,
+        ),
+        Keytest(
+          secondPlayer,
+        ),
+      ],
+      player: HumanPlayer(
+        position: Vector2(tileSize * 5, tileSize * 6),
+      ),
+      components: [secondPlayer],
+      cameraConfig: CameraConfig(
+        zoom: getZoomFromMaxVisibleTile(context, tileSize, 20),
+      ),
+      backgroundColor: const Color(0xff20a0b4),
+    );
+  }
+}
+
+class Keytest extends Keyboard {
+  Keytest(PlayerControllerListener o)
+      : super(
+            config: KeyboardConfig(
+              directionalKeys: [
+                KeyboardDirectionalKeys.wasd(),
+              ],
+            ),
+            observer: o);
+
+  @override
+  bool onKeyboard(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
+    print(keyboardConfig.directionalKeys.first.down);
+    return super.onKeyboard(event, keysPressed);
+  }
+}

--- a/example/lib/pages/player_controllers/player_controllers_page.dart
+++ b/example/lib/pages/player_controllers/player_controllers_page.dart
@@ -1,5 +1,4 @@
 import 'package:bonfire/bonfire.dart';
-import 'package:flutter/src/services/keyboard_key.g.dart';
 import 'package:flutter/widgets.dart';
 
 import '../player/simple/human.dart';
@@ -35,8 +34,13 @@ class PlayerControllersPage extends StatelessWidget {
           directional: JoystickDirectional(alignment: Alignment.centerRight),
           observer: secondPlayer,
         ),
-        Keytest(
-          secondPlayer,
+        Keyboard(
+          config: KeyboardConfig(
+            directionalKeys: [
+              KeyboardDirectionalKeys.wasd(),
+            ],
+          ),
+          observer: secondPlayer,
         ),
       ],
       player: HumanPlayer(
@@ -48,22 +52,5 @@ class PlayerControllersPage extends StatelessWidget {
       ),
       backgroundColor: const Color(0xff20a0b4),
     );
-  }
-}
-
-class Keytest extends Keyboard {
-  Keytest(PlayerControllerListener o)
-      : super(
-            config: KeyboardConfig(
-              directionalKeys: [
-                KeyboardDirectionalKeys.wasd(),
-              ],
-            ),
-            observer: o);
-
-  @override
-  bool onKeyboard(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
-    print(keyboardConfig.directionalKeys.first.down);
-    return super.onKeyboard(event, keysPressed);
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.8.0"
+    version: "3.8.7"
   boolean_selector:
     dependency: transitive
     description:
@@ -246,10 +246,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -560,5 +560,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.3.0-0 <4.0.0"
   flutter: ">=3.19.0"

--- a/lib/base/bonfire_game_interface.dart
+++ b/lib/base/bonfire_game_interface.dart
@@ -24,7 +24,7 @@ import 'package:flutter/widgets.dart';
 abstract class BonfireGameInterface {
   BuildContext get context;
   Player? get player;
-  PlayerController? get joystick;
+  List<PlayerController>? get playerControllers;
   LightingInterface? get lighting;
   ColorFilterInterface? get colorFilter;
   BonfireCamera get camera;

--- a/lib/input/input.dart
+++ b/lib/input/input.dart
@@ -2,5 +2,5 @@ export 'package:bonfire/input/gestures/drag_gesture.dart';
 export 'package:bonfire/input/gestures/gesture_event.dart';
 export 'package:bonfire/input/gestures/tap_gesture.dart';
 export 'package:bonfire/input/keyboard/keyboard_listener.dart';
-export 'package:bonfire/input/keyboard/keyboard_player_controller.dart';
+export 'package:bonfire/input/keyboard/keyboard.dart';
 export 'package:bonfire/input/mouse_listener.dart';

--- a/lib/input/input.dart
+++ b/lib/input/input.dart
@@ -2,4 +2,5 @@ export 'package:bonfire/input/gestures/drag_gesture.dart';
 export 'package:bonfire/input/gestures/gesture_event.dart';
 export 'package:bonfire/input/gestures/tap_gesture.dart';
 export 'package:bonfire/input/keyboard/keyboard_listener.dart';
+export 'package:bonfire/input/keyboard/keyboard_player_controller.dart';
 export 'package:bonfire/input/mouse_listener.dart';

--- a/lib/input/keyboard/keyboard.dart
+++ b/lib/input/keyboard/keyboard.dart
@@ -6,17 +6,15 @@ export 'package:bonfire/input/keyboard/keyboard_config.dart';
 class Keyboard extends PlayerController with KeyboardEventListener {
   bool _directionalIsIdle = false;
 
-  KeyboardConfig keyboardConfig = KeyboardConfig();
+  final KeyboardConfig keyboardConfig;
 
   /// Class responsible to adds a keyboard controller in your game.
   /// If pass [oberver] this param, the joystick will controll this observer and not the Component passed in `player` param.
   Keyboard({
+    super.id,
     KeyboardConfig? config,
     PlayerControllerListener? observer,
-  }) {
-    if (config != null) {
-      keyboardConfig = config;
-    }
+  }) : keyboardConfig = config ?? KeyboardConfig() {
     if (observer != null) {
       addObserver(observer);
     }

--- a/lib/input/keyboard/keyboard.dart
+++ b/lib/input/keyboard/keyboard.dart
@@ -8,6 +8,8 @@ class Keyboard extends PlayerController with KeyboardEventListener {
 
   KeyboardConfig keyboardConfig = KeyboardConfig();
 
+  /// Class responsible to adds a keyboard controller in your game.
+  /// If pass [oberver] this param, the joystick will controll this observer and not the Component passed in `player` param.
   Keyboard({
     KeyboardConfig? config,
     PlayerControllerListener? observer,

--- a/lib/input/keyboard/keyboard_config.dart
+++ b/lib/input/keyboard/keyboard_config.dart
@@ -38,7 +38,7 @@ class KeyboardDirectionalKeys {
 
 class KeyboardConfig {
   /// Use to enable ou disable keyboard events
-  final bool enable;
+  bool enable;
 
   /// Type of the directional (arrows, wasd or wasdAndArrows)
   final List<KeyboardDirectionalKeys> directionalKeys;
@@ -47,7 +47,7 @@ class KeyboardConfig {
   final List<LogicalKeyboardKey>? acceptedKeys;
 
   /// Use to enable diagonal input events
-  final bool enableDiagonalInput;
+  bool enableDiagonalInput;
 
   KeyboardConfig({
     this.enable = true,

--- a/lib/input/keyboard/keyboard_player_controller.dart
+++ b/lib/input/keyboard/keyboard_player_controller.dart
@@ -3,18 +3,17 @@ import 'package:flutter/services.dart';
 
 export 'package:bonfire/input/keyboard/keyboard_config.dart';
 
-class Keyboard extends PlayerController
-    with KeyboardEventListener {
+class Keyboard extends PlayerController with KeyboardEventListener {
   bool _directionalIsIdle = false;
 
   KeyboardConfig keyboardConfig = KeyboardConfig();
 
   Keyboard({
-    KeyboardConfig? keyboardConfig,
+    KeyboardConfig? config,
     PlayerControllerListener? observer,
   }) {
-    if (keyboardConfig != null) {
-      this.keyboardConfig = keyboardConfig;
+    if (config != null) {
+      keyboardConfig = config;
     }
     if (observer != null) {
       addObserver(observer);

--- a/lib/input/keyboard/keyboard_player_controller.dart
+++ b/lib/input/keyboard/keyboard_player_controller.dart
@@ -1,16 +1,23 @@
 import 'package:bonfire/bonfire.dart';
 import 'package:flutter/services.dart';
 
-class ControlByKeyboard extends PlayerController with KeyboardEventListener {
+export 'package:bonfire/input/keyboard/keyboard_config.dart';
+
+class Keyboard extends PlayerController
+    with KeyboardEventListener {
   bool _directionalIsIdle = false;
 
   KeyboardConfig keyboardConfig = KeyboardConfig();
 
-  ControlByKeyboard({
+  Keyboard({
     KeyboardConfig? keyboardConfig,
+    PlayerControllerListener? observer,
   }) {
     if (keyboardConfig != null) {
       this.keyboardConfig = keyboardConfig;
+    }
+    if (observer != null) {
+      addObserver(observer);
     }
   }
 

--- a/lib/input/player_controller.dart
+++ b/lib/input/player_controller.dart
@@ -108,6 +108,8 @@ abstract class PlayerController extends GameComponent {
     return _observers.contains(listener);
   }
 
+  bool get containObservers => _observers.isNotEmpty;
+
   @override
   int get priority {
     return LayerPriority.getHudJoystickPriority();

--- a/lib/joystick/joystick.dart
+++ b/lib/joystick/joystick.dart
@@ -10,6 +10,7 @@ class Joystick extends PlayerController {
   /// Class responsable to adds a joystick controller in your game.
   /// If pass [oberver] this param, the joystick will controll this observer and not the Component passed in `player` param.
   Joystick({
+    super.id,
     this.actions = const [],
     JoystickDirectional? directional,
     PlayerControllerListener? observer,

--- a/lib/joystick/joystick.dart
+++ b/lib/joystick/joystick.dart
@@ -7,6 +7,8 @@ class Joystick extends PlayerController {
 
   JoystickDirectional? get directional => _directional;
 
+  /// Class responsable to adds a joystick controller in your game.
+  /// If pass [oberver] this param, the joystick will controll this observer and not the Component passed in `player` param.
   Joystick({
     this.actions = const [],
     JoystickDirectional? directional,

--- a/lib/joystick/joystick.dart
+++ b/lib/joystick/joystick.dart
@@ -1,8 +1,6 @@
 import 'package:bonfire/bonfire.dart';
 import 'package:flutter/widgets.dart';
 
-export 'package:bonfire/input/keyboard/keyboard_config.dart';
-
 class Joystick extends PlayerController {
   final List<JoystickAction> actions;
   JoystickDirectional? _directional;
@@ -12,8 +10,12 @@ class Joystick extends PlayerController {
   Joystick({
     this.actions = const [],
     JoystickDirectional? directional,
+    PlayerControllerListener? observer,
   }) {
     _directional = directional;
+    if (observer != null) {
+      addObserver(observer);
+    }
   }
 
   void initialize(Vector2 size) async {

--- a/lib/joystick/joystick_action.dart
+++ b/lib/joystick/joystick_action.dart
@@ -3,9 +3,6 @@ import 'dart:math';
 import 'package:bonfire/bonfire.dart';
 import 'package:flutter/material.dart';
 
-// ignore: constant_identifier_names
-enum JoystickActionAlign { TOP_LEFT, BOTTOM_LEFT, TOP_RIGHT, BOTTOM_RIGHT }
-
 class JoystickAction {
   final dynamic actionId;
   Sprite? sprite;
@@ -14,11 +11,11 @@ class JoystickAction {
   final double sizeFactorBackgroundDirection;
   final double size;
   final EdgeInsets margin;
-  final JoystickActionAlign align;
   final bool enableDirection;
   final Color color;
   final double opacityBackground;
   final double opacityKnob;
+  final Alignment alignment;
 
   late double _sizeBackgroundDirection;
   late double _tileSize;
@@ -45,9 +42,9 @@ class JoystickAction {
     this.enableDirection = false,
     this.size = 50,
     this.sizeFactorBackgroundDirection = 1.5,
-    this.margin = EdgeInsets.zero,
+    this.margin = const EdgeInsets.all(50),
     this.color = Colors.blueGrey,
-    this.align = JoystickActionAlign.BOTTOM_RIGHT,
+    this.alignment = Alignment.bottomRight,
     this.opacityBackground = 0.5,
     this.opacityKnob = 0.8,
   }) {
@@ -67,32 +64,21 @@ class JoystickAction {
   void initialize(Vector2 screenSize, PlayerController joystickController) {
     _joystickController = joystickController;
     double radius = size / 2;
-    double dx = 0, dy = 0;
-    switch (align) {
-      case JoystickActionAlign.TOP_LEFT:
-        dx = margin.left + radius;
-        dy = margin.top + radius;
-        break;
-      case JoystickActionAlign.BOTTOM_LEFT:
-        dx = margin.left + radius;
-        dy = screenSize.y - (margin.bottom + radius);
-        break;
-      case JoystickActionAlign.TOP_RIGHT:
-        dx = screenSize.x - (margin.right + radius);
-        dy = margin.top + radius;
-        break;
-      case JoystickActionAlign.BOTTOM_RIGHT:
-        dx = screenSize.x - (margin.right + radius);
-        dy = screenSize.y - (margin.bottom + radius);
-        break;
-    }
+    final screenRect = Rect.fromLTRB(
+      margin.left + radius,
+      margin.top + radius,
+      screenSize.x - margin.right - radius,
+      screenSize.y - margin.bottom - radius,
+    );
+
+    Offset osBackground = alignment.withinRect(screenRect);
     _rect = Rect.fromCircle(
-      center: Offset(dx, dy),
+      center: osBackground,
       radius: radius,
     );
 
     _rectBackgroundDirection = Rect.fromCircle(
-      center: Offset(dx, dy),
+      center: osBackground,
       radius: _sizeBackgroundDirection / 2,
     );
 

--- a/lib/joystick/joystick_directional.dart
+++ b/lib/joystick/joystick_directional.dart
@@ -34,12 +34,14 @@ class JoystickDirectional {
 
   /// Use to enable diagonal input events
   final bool enableDiagonalInput;
+  final Alignment alignment;
 
   JoystickDirectional({
     Future<Sprite>? spriteBackgroundDirectional,
     Future<Sprite>? spriteKnobDirectional,
     this.isFixed = true,
-    this.margin = const EdgeInsets.only(left: 100, bottom: 100),
+    this.margin = const EdgeInsets.all(100),
+    this.alignment = Alignment.bottomLeft,
     this.size = 80,
     this.color = Colors.blueGrey,
     this.enableDiagonalInput = true,
@@ -58,13 +60,20 @@ class JoystickDirectional {
   void initialize(Vector2 screenSize, PlayerController joystickController) {
     _screenSize = screenSize;
     _joystickController = joystickController;
-    Offset osBackground = Offset(
-      margin.left,
-      screenSize.y - margin.bottom,
+    final radius = size / 2;
+
+    final screenRect = Rect.fromLTRB(
+      margin.left + radius,
+      margin.top + radius,
+      screenSize.x - margin.right - radius,
+      screenSize.y - margin.bottom - radius,
     );
+
+    Offset osBackground = alignment.withinRect(screenRect);
+
     _backgroundRect = Rect.fromCircle(
       center: osBackground,
-      radius: size / 2,
+      radius: radius,
     );
 
     Offset osKnob = Offset(

--- a/lib/joystick/joystick_directional.dart
+++ b/lib/joystick/joystick_directional.dart
@@ -289,10 +289,18 @@ class JoystickDirectional {
   }
 
   void _updateDirectionalRect(Offset position) {
-    if (_screenSize != null &&
-        (position.dx > _screenSize!.x / 3 ||
-            position.dy < _screenSize!.y / 3 ||
-            isFixed)) return;
+    if (isFixed || _screenSize == null) return;
+    if (alignment.x == -1) {
+      if (position.dx > _screenSize!.x * 0.33) {
+        return;
+      }
+    }
+
+    if (alignment.x == 1) {
+      if (position.dx < _screenSize!.x * 0.66) {
+        return;
+      }
+    }
 
     _backgroundRect = Rect.fromCircle(
       center: position,

--- a/lib/mixins/movement_by_joystick.dart
+++ b/lib/mixins/movement_by_joystick.dart
@@ -68,7 +68,7 @@ mixin MovementByJoystick on Movement, PlayerControllerListener {
   @override
   void update(double dt) {
     super.update(dt);
-    if (_isEnabled()) {
+    if (_settings.enabled) {
       _handleChangeDirectional();
       if (_isMoveByDirection) {
         _moveDirectional(_currentDirectional, _intensitySpeed);
@@ -161,11 +161,6 @@ mixin MovementByJoystick on Movement, PlayerControllerListener {
     _joystickAngle = 0;
     _lastSpeed = 0;
     super.idle();
-  }
-
-  bool _isEnabled() {
-    return (gameRef.joystick?.containObserver(this) ?? false) &&
-        _settings.enabled;
   }
 
   void _toCorrectDirection(JoystickMoveDirectional directional) {

--- a/lib/mixins/use_barlife.dart
+++ b/lib/mixins/use_barlife.dart
@@ -12,7 +12,7 @@ mixin UseLifeBar on Attackable {
   Vector2? _barOffset;
   Vector2? _textOffset;
   BorderRadius _borderRadius = BorderRadius.zero;
-  BarLifeDrawPorition _barLifeDrawPosition = BarLifeDrawPorition.bottom;
+  BarLifeDrawPosition _barLifeDrawPosition = BarLifeDrawPosition.bottom;
   TextStyle? _textStyle;
   bool _showLifeText = true;
   ValueGeneratorComponent? _valueGenerator;
@@ -25,7 +25,7 @@ mixin UseLifeBar on Attackable {
     double borderWidth = 2,
     List<Color>? colors,
     BorderRadius? borderRadius,
-    BarLifeDrawPorition barLifeDrawPosition = BarLifeDrawPorition.top,
+    BarLifeDrawPosition barLifeDrawPosition = BarLifeDrawPosition.top,
     Vector2? offset,
     Vector2? textOffset,
     TextStyle? textStyle,

--- a/lib/util/barlife_component.dart
+++ b/lib/util/barlife_component.dart
@@ -1,7 +1,7 @@
 import 'package:bonfire/bonfire.dart';
 import 'package:flutter/material.dart';
 
-enum BarLifeDrawPorition { top, bottom, left, right }
+enum BarLifeDrawPosition { top, bottom, left, right }
 
 typedef BarLifeTextBuilder = String Function(double life, double maxLife);
 
@@ -10,7 +10,7 @@ class BarLifeComponent extends GameComponent {
   final Paint _barLifePaint = Paint()..style = PaintingStyle.fill;
   Paint _barLifeBorderPaint = Paint();
 
-  final BarLifeDrawPorition drawPosition;
+  final BarLifeDrawPosition drawPosition;
   final List<Color>? colors;
   final Color backgroundColor;
   final BorderRadius borderRadius;
@@ -36,7 +36,7 @@ class BarLifeComponent extends GameComponent {
     required Vector2 size,
     Vector2? offset,
     Vector2? textOffset,
-    this.drawPosition = BarLifeDrawPorition.top,
+    this.drawPosition = BarLifeDrawPosition.top,
     this.colors,
     this.textStyle,
     this.showLifeText = true,
@@ -75,16 +75,16 @@ class BarLifeComponent extends GameComponent {
     double yPosition = (y - height);
     double xPosition = (target.size.x - width) / 2;
     switch (drawPosition) {
-      case BarLifeDrawPorition.top:
+      case BarLifeDrawPosition.top:
         break;
-      case BarLifeDrawPorition.bottom:
+      case BarLifeDrawPosition.bottom:
         yPosition = target.size.y + y;
         break;
-      case BarLifeDrawPorition.left:
+      case BarLifeDrawPosition.left:
         xPosition = -width + x;
         yPosition = (target.size.y / 2 - height / 2) + y;
         break;
-      case BarLifeDrawPorition.right:
+      case BarLifeDrawPosition.right:
         xPosition = width + x;
         yPosition = (target.size.y / 2 - height / 2) + y;
         break;

--- a/lib/widgets/bonfire_widget.dart
+++ b/lib/widgets/bonfire_widget.dart
@@ -7,7 +7,6 @@ import 'package:bonfire/camera/camera_config.dart';
 import 'package:bonfire/color_filter/game_color_filter.dart';
 import 'package:bonfire/forces/forces_2d.dart';
 import 'package:bonfire/game_interface/game_interface.dart';
-import 'package:bonfire/input/keyboard/keyboard_config.dart';
 import 'package:bonfire/input/player_controller.dart';
 import 'package:bonfire/map/base/game_map.dart';
 import 'package:bonfire/player/player.dart';
@@ -15,7 +14,7 @@ import 'package:flutter/material.dart';
 
 class BonfireWidget extends StatefulWidget {
   /// The player-controlling component.
-  final PlayerController? joystick;
+  final List<PlayerController>? playerControllers;
 
   /// Represents the character controlled by the user in the game. Instances of this class has actions and movements ready to be used and configured.
   final Player? player;
@@ -62,13 +61,11 @@ class BonfireWidget extends StatefulWidget {
   final GameColorFilter? colorFilter;
   final VoidCallback? onDispose;
   final List<Force2D>? globalForces;
-  final KeyboardConfig? keyboardConfig;
 
   const BonfireWidget({
     Key? key,
     required this.map,
-    this.joystick,
-    this.keyboardConfig,
+    this.playerControllers,
     this.player,
     this.interface,
     this.background,
@@ -124,9 +121,8 @@ class BonfireWidgetState extends State<BonfireWidget> {
 
   void _buildGame() {
     _game = BonfireGame(
-      keyboardConfig: widget.keyboardConfig,
       context: context,
-      joystickController: widget.joystick,
+      playerControllers: widget.playerControllers,
       player: widget.player,
       interface: widget.interface,
       map: widget.map,

--- a/lib/widgets/bonfire_widget.dart
+++ b/lib/widgets/bonfire_widget.dart
@@ -13,7 +13,7 @@ import 'package:bonfire/player/player.dart';
 import 'package:flutter/material.dart';
 
 class BonfireWidget extends StatefulWidget {
-  /// The player-controlling component.
+  /// Controls the player in the game. You can pass a list of controllers to control the player in different ways.
   final List<PlayerController>? playerControllers;
 
   /// Represents the character controlled by the user in the game. Instances of this class has actions and movements ready to be used and configured.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -103,26 +103,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -151,10 +151,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   ordered_set:
     dependency: transitive
     description:
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   tiledjsonreader:
     dependency: "direct main"
     description:
@@ -252,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bonfire
 description: (RPG maker) Create RPG-style or similar games more simply with Flame.
-version: 3.8.7
+version: 3.9.0
 homepage: https://bonfire-engine.github.io
 repository: https://github.com/RafaelBarbosatec/bonfire
 issue_tracker: https://github.com/RafaelBarbosatec/bonfire/issues


### PR DESCRIPTION
- `JoystickDirectional` improvements. Now you can use `Alignment`.
- `JoystickAction` improvements. Now you can use `Alignment`.
- Adds param `PlayerControllerListener? observer` in `Joystick`. If pass this param, the joystick will controll this observer and not the Component passed in `player` param.
- Adds param `PlayerControllerListener? observer` in `Keyboard`. If pass this param, the keyboard will controll this observer and not the Component passed in `player` param.
- Fix type `BarLifeDrawPosition`. [#515](https://github.com/RafaelBarbosatec/bonfire/issues/515)

**Breaking Changes:**
  - `BonfireWidget` expect `List<PlayerController>? playerControllers` instead of `joystick`. With this improvements is possible pass multi ways to control de player or any component that contains the mixin `PlayerControllerListener`(use `MovementByJoystick` to move automatic by PlayerController interactions). With this improvements it's possible create a local multiplayer.
  - Removed `keyboardConfig` param from `BonfireWidget`. Now pass `Keyboard` instance in `playerControllers`.
  Example using joystick and keyboard:
  ```dart
    return BonfireWidget(
      map: ...,
      playerControllers: [
        Joystick(directional: JoystickDirectional()),
        Keyboard(),
      ],
      player: HumanPlayer(
        position: Vector2(100, 100),
      ),
    );
  ```