### PR TITLE
Add guard to prevent `onDestroy` being called after component has been removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.9.5
-
 - Fix Joystick bug when viewport is fixed resolution. [#526](https://github.com/RafaelBarbosatec/bonfire/issues/526)
+- Add guard in `FlyingAttackGameObject` to prevent calling `onDestroy` after component has been destroyed.
 
 # 3.9.4
 - Fix bug in `FollowerWidget`.

--- a/lib/objects/flying_attack_game_object.dart
+++ b/lib/objects/flying_attack_game_object.dart
@@ -135,10 +135,11 @@ class FlyingAttackGameObject extends AnimatedGameObject
     if (isRemoving || isRemoved) return;
     removeFromParent();
     if (animationDestroy != null) {
-      if (direction != null) {
-        _destroyByDirection(direction!, dtUpdate, component);
+      final currentDirection = direction;
+      if (currentDirection != null) {
+        _destroyByDirection(currentDirection);
       } else {
-        _destroyByAngle(component);
+        _destroyByAngle();
       }
     }
     removeAll(children);
@@ -149,11 +150,7 @@ class FlyingAttackGameObject extends AnimatedGameObject
     return gameRef.map.toRect().contains(center.toOffset());
   }
 
-  void _destroyByDirection(
-    Direction direction,
-    double dt,
-    GameComponent component,
-  ) {
+  void _destroyByDirection(Direction direction) {
     Vector2 positionDestroy;
 
     double biggerSide = max(width, height);
@@ -236,12 +233,11 @@ class FlyingAttackGameObject extends AnimatedGameObject
           innerSize.x,
           innerSize.y,
         ),
-        component,
       );
     }
   }
 
-  void _destroyByAngle(GameComponent component) {
+  void _destroyByAngle() {
     double nextX = (width / 2) * _cosAngle;
     double nextY = (height / 2) * _senAngle;
 
@@ -277,12 +273,11 @@ class FlyingAttackGameObject extends AnimatedGameObject
           innerSize.x,
           innerSize.y,
         ),
-        component,
       );
     }
   }
 
-  void _applyDestroyDamage(Rect rectPosition, GameComponent component) {
+  void _applyDestroyDamage(Rect rectPosition) {
     gameRef.add(
       DamageHitbox(
         id: id,

--- a/lib/objects/flying_attack_game_object.dart
+++ b/lib/objects/flying_attack_game_object.dart
@@ -132,7 +132,7 @@ class FlyingAttackGameObject extends AnimatedGameObject
   }
 
   void _destroyObject(GameComponent component) {
-    if (isRemoving) return;
+    if (isRemoving || isRemoved) return;
     removeFromParent();
     if (animationDestroy != null) {
       if (direction != null) {


### PR DESCRIPTION
# Description

- Add guard in `FlyingAttackGameObject` to prevent calling `onDestroy` after component has been destroyed.
- Refactor: remove redundant parameters

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `dart format --output=none --set-exit-if-changed .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.
