### PR TITLE
Fix bug where character goes into jump mode on slanting floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.9.5
 - Fix Joystick bug when viewport is fixed resolution. [#526](https://github.com/RafaelBarbosatec/bonfire/issues/526)
 - Add guard in `FlyingAttackGameObject` to prevent calling `onDestroy` after component has been destroyed.
+- Fix jump animation showing instead of run/idle animation on slanting floors
 
 # 3.9.4
 - Fix bug in `FollowerWidget`.

--- a/lib/mixins/jumper.dart
+++ b/lib/mixins/jumper.dart
@@ -58,7 +58,7 @@ mixin Jumper on Movement, BlockMovementCollision {
   @override
   void onCollisionStart(
       Set<Vector2> intersectionPoints, PositionComponent other) {
-    if (other is CollisionMapComponent) {
+    if (other is CollisionMapComponent || other is TileWithCollision) {
       ++_tileCollisionCount;
       resetInterval(_tileCollisionCountKey);
     }
@@ -67,7 +67,7 @@ mixin Jumper on Movement, BlockMovementCollision {
 
   @override
   void onCollisionEnd(PositionComponent other) {
-    if (other is CollisionMapComponent) {
+    if (other is CollisionMapComponent || other is TileWithCollision) {
       if (--_tileCollisionCount == 0) resetInterval(_tileCollisionCountKey);
     }
     super.onCollisionEnd(other);

--- a/lib/mixins/jumper.dart
+++ b/lib/mixins/jumper.dart
@@ -1,4 +1,5 @@
 import 'package:bonfire/bonfire.dart';
+import 'package:bonfire/util/collision_game_component.dart';
 
 enum JumpingStateEnum {
   up,
@@ -20,6 +21,9 @@ mixin Jumper on Movement, BlockMovementCollision {
   int _maxJump = 1;
   int _currentJumps = 0;
   JumpingStateEnum? _lastDirectionJump = JumpingStateEnum.idle;
+  int _tileCollisionCount = 0;
+
+  static const _tileCollisionCountKey = 'tileCollisionCount';
 
   void onJump(JumpingStateEnum state) {
     jumpingState = state;
@@ -42,22 +46,44 @@ mixin Jumper on Movement, BlockMovementCollision {
     PositionComponent other,
     CollisionData collisionData,
   ) {
-    super.onBlockedMovement(other, collisionData);
     if (isJumping &&
         lastDirectionVertical.isDownSide &&
         collisionData.direction.isDownSide) {
       _currentJumps = 0;
       isJumping = false;
     }
+    super.onBlockedMovement(other, collisionData);
+  }
+
+  @override
+  void onCollisionStart(
+      Set<Vector2> intersectionPoints, PositionComponent other) {
+    if (other is CollisionMapComponent) {
+      ++_tileCollisionCount;
+      resetInterval(_tileCollisionCountKey);
+    }
+    super.onCollisionStart(intersectionPoints, other);
+  }
+
+  @override
+  void onCollisionEnd(PositionComponent other) {
+    if (other is CollisionMapComponent) {
+      if (--_tileCollisionCount == 0) resetInterval(_tileCollisionCountKey);
+    }
+    super.onCollisionEnd(other);
   }
 
   @override
   void update(double dt) {
-    super.update(dt);
-    if (!isJumping && displacement.y.abs() > 0.2) {
+    if (checkInterval(_tileCollisionCountKey, 100, dt,
+            firstCheckIsTrue: false) &&
+        !isJumping &&
+        _tileCollisionCount == 0 &&
+        displacement.y.abs() > 0.2) {
       isJumping = true;
     }
     _notifyJump();
+    super.update(dt);
   }
 
   void _notifyJump() {


### PR DESCRIPTION
# Description

- Character displays run animation instead of jump animation on slanting tiles

To elaborate on what this PR does:

Before the change:

https://github.com/RafaelBarbosatec/bonfire/assets/7362366/fb334cdb-9b05-49c9-80ea-ce955ff2bd20

After the change:

https://github.com/RafaelBarbosatec/bonfire/assets/7362366/ed80be47-951a-47f0-871e-28b8e4222320



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `dart format --output=none --set-exit-if-changed .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.
