### PR TITLE
Fix: MatrixLayer axisInverted field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.9.9
+- Update `lgjenero`
+- Bugfix/MatrixLayer axisInverted. [#535](https://github.com/RafaelBarbosatec/bonfire/pull/545)
+- Makes it possible to set 'axisInverted' in `MatrixLayer` constructor.
+
 # 3.9.8
 - Fix bug when hitbox anchor is center.
 - BREAKING CHANGE: Update `bool receiveDamage` to `void onReceiveDamage`. Now to perform receive of attack use `handleAttack` method.

--- a/lib/map/matrix_map/matrix_layer.dart
+++ b/lib/map/matrix_map/matrix_layer.dart
@@ -1,9 +1,9 @@
 class MatrixLayer {
-  final bool axisInverted = false;
+  final bool axisInverted;
   final List<List<double>> matrix;
 
   MatrixLayer({
     required this.matrix,
-    axisInverted = false,
+    this.axisInverted = false,
   });
 }


### PR DESCRIPTION
# Description

`MatrixLayer` class had a bug making it impossible to set `axisInverted` field. The PR makes the `axisInverted` set by the constructor.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `dart format --output=none --set-exit-if-changed .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x ] No, this is *not* a breaking change.
