### PR TITLE
Added feature to support infinite maps.

### DIFF
--- a/lib/base/game_component.dart
+++ b/lib/base/game_component.dart
@@ -14,6 +14,7 @@ abstract class GameComponent extends PositionComponent
         CollisionCallbacks {
   final String _keyIntervalCheckIsVisible = "CHECK_VISIBLE";
   final int _intervalCheckIsVisible = 100;
+  final int _priorityOffset = 100000;
   Map<String, dynamic>? properties;
 
   /// When true this component render above all components in game.
@@ -50,9 +51,9 @@ abstract class GameComponent extends PositionComponent
   @override
   int get priority {
     if (renderAboveComponents && hasGameRef) {
-      return LayerPriority.getAbovePriority(gameRef.highestPriority);
+      return LayerPriority.getAbovePriority(gameRef.highestPriority) + _priorityOffset;
     }
-    return LayerPriority.getComponentPriority(rectCollision.bottom.floor());
+    return LayerPriority.getComponentPriority(rectCollision.bottom.floor()) + _priorityOffset;
   }
 
   @override

--- a/lib/camera/bonfire_camera.dart
+++ b/lib/camera/bonfire_camera.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:bonfire/bonfire.dart';
 import 'package:bonfire/camera/camera_effects.dart';
+import 'package:bonfire/map/tiled/world_map_infinite_by_tiled.dart';
 import 'package:flame/experimental.dart';
 
 // Custom implmentation of Flame's `CameraComponent`
@@ -245,16 +246,44 @@ class BonfireCamera extends CameraComponent with BonfireHasGameRef {
     }
     config.moveOnlyMapArea = enabled;
     if (enabled) {
-      setBounds(
-        Rectangle.fromRect(
-          gameRef.map.getMapRect().deflatexy(
-                visibleWorldRect.width / 2,
-                visibleWorldRect.height / 2,
-              ),
-        ),
-      );
+      setBounds(_getBoundsMoveAreaByMapType());
     } else {
       setBounds(null);
+    }
+  }
+
+  Shape? _getBoundsMoveAreaByMapType() {
+    final mapRect = gameRef.map.getMapRect();
+    final deflateWidth = visibleWorldRect.width / 2;
+    final deflateHeight = visibleWorldRect.height / 2;
+
+    if (gameRef.map is WorldMapInfiniteByTiled) {
+      return _getBoundsMoveAreaWorldMapInfinite(mapRect, deflateWidth, deflateHeight);
+    }
+
+    return Rectangle.fromRect(
+      mapRect.deflatexy(deflateWidth, deflateHeight),
+    );
+  }
+
+  Rectangle? _getBoundsMoveAreaWorldMapInfinite(Rect mapRect, double deflateWidth, double deflateHeight) {
+    final mapType = (gameRef.map as WorldMapInfiniteByTiled).type;
+    
+    switch (mapType) {
+      case InfiniteWorldMapType.OPEN:
+        return null;
+      case InfiniteWorldMapType.VERTICAL:
+        return Rectangle.fromRect(
+          mapRect.deflatexy(deflateWidth, double.maxFinite),
+        );
+      case InfiniteWorldMapType.HORIZONTAL:
+        return Rectangle.fromRect(
+          mapRect.deflatexy(double.maxFinite, deflateHeight),
+        );
+      default:
+        return Rectangle.fromRect(
+          mapRect.deflatexy(deflateWidth, deflateHeight),
+        );
     }
   }
 

--- a/lib/map/base/tile_layer_component.dart
+++ b/lib/map/base/tile_layer_component.dart
@@ -58,15 +58,16 @@ class TileLayerComponent extends PositionComponent with HasPaint {
     }
   }
 
-  void initLayer(Vector2 gameSize, Vector2 screenSize) {
+  void initLayer(Vector2 gameSize, Vector2 screenSize, {bool infiniteMap = false,}) {
     if (gameSize.isZero()) return;
-    _createQuadTree(gameSize, screenSize);
+    _createQuadTree(gameSize, screenSize, infiniteMap: infiniteMap);
   }
 
   void _createQuadTree(
     Vector2 mapSize,
     Vector2 screenSize, {
     bool force = false,
+    bool infiniteMap = false,
   }) {
     if (_lastScreenSize == screenSize && !force) return;
     _lastScreenSize = screenSize.clone();
@@ -77,13 +78,7 @@ class TileLayerComponent extends PositionComponent with HasPaint {
     int maxItems = 100;
     final minScreen = min(screenSize.x, screenSize.y);
     maxItems = ((minScreen / tileSize) / 2).ceil();
-    _quadTree = tree.QuadTree(
-      0,
-      0,
-      treeSize.x,
-      treeSize.y,
-      maxItems: maxItems,
-    );
+    _quadTree = infiniteMap ? _createInfiniteQuadTree(maxItems) : _createFiniteQuadTree(treeSize, maxItems);
 
     for (var tile in _tiles) {
       _quadTree?.insert(
@@ -92,6 +87,30 @@ class TileLayerComponent extends PositionComponent with HasPaint {
         id: tile.id,
       );
     }
+  }
+
+  tree.QuadTree<Tile> _createInfiniteQuadTree(int maxItems) {
+    return tree.QuadTree(
+      -90000,
+      -90000,
+      100000,
+      100000,
+      maxItems: maxItems,
+    );
+  }
+
+  tree.QuadTree<Tile> _createFiniteQuadTree(Vector2 treeSize, int maxItems) {
+    return tree.QuadTree(
+      0,
+      0,
+      treeSize.x,
+      treeSize.y,
+      maxItems: maxItems,
+    );
+  }
+
+  List<Tile> getTiles() {
+    return _tiles;
   }
 
   void updateTiles(List<Tile> tiles) {

--- a/lib/map/tiled/builder/tiled_world_builder.dart
+++ b/lib/map/tiled/builder/tiled_world_builder.dart
@@ -69,7 +69,7 @@ class TiledWorldBuilder {
     _objectsBuilder[name] = builder;
   }
 
-  Future<WorldBuildData> build() async {
+  Future<WorldBuildData> build({bool onlyObjects = false}) async {
     try {
       _tiledMap = await reader.readMap();
       if (_tiledMap?.orientation != _mapOrientationSupported) {
@@ -81,7 +81,7 @@ class TiledWorldBuilder {
       _tileHeightOrigin = _tiledMap?.tileHeight?.toDouble() ?? 0.0;
       _tileWidth = forceTileSize?.x ?? _tileWidthOrigin;
       _tileHeight = forceTileSize?.y ?? _tileHeightOrigin;
-      await _load(_tiledMap!);
+      await _load(_tiledMap!, onlyObjects: onlyObjects);
     } catch (e) {
       onError?.call(e);
       // ignore: avoid_print
@@ -99,14 +99,14 @@ class TiledWorldBuilder {
     );
   }
 
-  Future<void> _load(TiledMap tiledMap) async {
+  Future<void> _load(TiledMap tiledMap, {bool onlyObjects = false}) async {
     for (var layer in tiledMap.layers ?? const <MapLayer>[]) {
-      await _loadLayer(layer);
+      await _loadLayer(layer, onlyObjects: onlyObjects);
     }
   }
 
-  Future<void> _loadLayer(MapLayer layer) async {
-    if (layer.visible != true) return;
+  Future<void> _loadLayer(MapLayer layer, {bool onlyObjects = false}) async {
+    if (layer.visible != true || (onlyObjects && layer is! ObjectLayer)) return;
 
     if (layer is tiled.TileLayer) {
       _layers.add(MapLayerMapper.toLayer(layer, countTileLayer));

--- a/lib/map/tiled/world_map_infinite_by_tiled.dart
+++ b/lib/map/tiled/world_map_infinite_by_tiled.dart
@@ -1,0 +1,211 @@
+import 'package:bonfire/bonfire.dart';
+import 'package:bonfire/map/tiled/builder/tiled_world_builder.dart';
+import 'package:flutter/widgets.dart';
+import 'package:tiledjsonreader/map/tiled_map.dart';
+
+enum InfiniteWorldMapType { OPEN, VERTICAL, HORIZONTAL }
+
+class WorldMapInfiniteByTiled extends WorldMap {
+  bool _isExecutingLoadChunk = false;
+  bool _isExecutingDistantChunk = false;
+
+  final Map<int, List<Tile>> initialTilesPerLayerMap = {};
+  final Set<String> loadedChunkIds = {};
+  final Map<String, Set<String>> loadedChunkTiles = {};
+  final Map<String, List<GameComponent>> loadedChunkComponents = {};
+
+  late TiledWorldBuilder _builder;
+  final List<GameComponent> _components = [];
+  late final double _chunkSizeX;
+  late final double _chunkSizeY;
+  final Map<String, ObjectBuilder>? objectsBuilder;
+  final InfiniteWorldMapType type;
+  final double cameraMargin;
+
+  WorldMapInfiniteByTiled(
+    WorldMapReader<TiledMap> reader, {
+    Vector2? forceTileSize,
+    ValueChanged<Object>? onError,
+    double sizeToUpdate = 0,
+    this.objectsBuilder,
+    this.type = InfiniteWorldMapType.OPEN,
+    this.cameraMargin = 100,
+  }) : super(const [], infinite: true) {
+    this.sizeToUpdate = sizeToUpdate;
+    _builder = TiledWorldBuilder(
+      reader,
+      forceTileSize: forceTileSize,
+      onError: onError,
+      sizeToUpdate: sizeToUpdate,
+      objectsBuilder: objectsBuilder,
+    );
+  }
+
+  @override
+  Future<void> onLoad() async {
+    final map = await _builder.build();
+    layers = map.map.layers;
+    if (map.components != null) {
+      _components.addAll(map.components!);
+    }
+    gameRef.addAll(_components);
+    await super.onLoad();
+
+    _chunkSizeX = size.x / tileSize;
+    _chunkSizeY = size.y / tileSize;
+     
+    _loadInitialTilesMap();
+  }
+
+  void _loadInitialTilesMap() {
+    loadedChunkIds.add(_getChunkId(0, 0));
+    for (var layerComponent in layersComponent) {
+      initialTilesPerLayerMap[layerComponent.id] = List.from(layerComponent.getTiles());
+    }
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    _loadChunks();
+  }
+
+  Future<void> _loadChunks() async {
+    if (_isExecutingLoadChunk) return;
+
+    _isExecutingLoadChunk = true;
+    _removeDistantChunks();
+    
+    final cameraBounds = gameRef.camera.visibleWorldRect;
+    final chunkSizeWidth = _chunkSizeX * tileSize;
+    final chunkSizeHeight = _chunkSizeY * tileSize;
+
+    int minChunkX = ((cameraBounds.left - cameraMargin) / chunkSizeWidth).floor();
+    int maxChunkX = ((cameraBounds.right + cameraMargin) / chunkSizeWidth).floor();
+    int minChunkY = ((cameraBounds.top - cameraMargin) / chunkSizeHeight).floor();
+    int maxChunkY = ((cameraBounds.bottom + cameraMargin) / chunkSizeHeight).floor();
+
+    if (type == InfiniteWorldMapType.VERTICAL) {
+      minChunkX = maxChunkX = 0;
+    } else if (type == InfiniteWorldMapType.HORIZONTAL) {
+      minChunkY = maxChunkY = 0;
+    }
+
+    for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+      for (int chunkY = minChunkY; chunkY <= maxChunkY; chunkY++) {
+        final chunkId = _getChunkId(chunkX, chunkY);
+        if (loadedChunkIds.contains(chunkId)) continue;
+
+        _buildLayersChunk(chunkId, chunkX, chunkY);
+        await _buildComponentsChunk(chunkId, chunkX, chunkY);
+
+        loadedChunkIds.add(chunkId);
+      }
+    }
+
+    _isExecutingLoadChunk = false;
+  }
+
+  void _buildLayersChunk(String chunkId, int chunkX, int chunkY) {
+    for (var layerComponent in layersComponent) {
+      final String layerChunkId = _getLayerChunkId(layerComponent.id, chunkId);
+      if (loadedChunkTiles.containsKey(layerChunkId)) continue;
+
+      final List<Tile> newTiles = initialTilesPerLayerMap[layerComponent.id]!
+          .map((tile) => _getTileCopy(tile, tile.x + chunkX * _chunkSizeX, tile.y + chunkY * _chunkSizeY))
+          .toList();
+
+      if (newTiles.isNotEmpty) {
+        loadedChunkTiles[layerChunkId] = newTiles.map((tile) => tile.id).toSet();
+        layerComponent.updateTiles([...layerComponent.getTiles(), ...newTiles]);
+      }
+    }
+  }
+
+  Future<void> _buildComponentsChunk(String chunkId, int chunkX, int chunkY) async {
+    final map = await _builder.build(onlyObjects: true);
+    final componentsToAdd = map.components?.where((component) => !_components.contains(component)).toList() ?? [];
+
+    if (componentsToAdd.isNotEmpty) {
+      final offset = Vector2(chunkX * _chunkSizeX * tileSize, chunkY * _chunkSizeY * tileSize);
+      for (var component in componentsToAdd) {
+        component.position += offset;
+      }
+
+      gameRef.addAll(componentsToAdd);
+      _components.addAll(componentsToAdd);
+    }
+
+    loadedChunkComponents[chunkId] = componentsToAdd;
+  }
+
+  Future<void> _removeDistantChunks({int chunkRange = 1}) async {
+    if (_isExecutingDistantChunk) return;
+    _isExecutingDistantChunk = true;
+
+    final currentChunk = getCurrentChunk(gameRef.camera.visibleWorldRect.centerVector2);
+    final List<String> chunksToRemove = [];
+
+    for (var chunkId in loadedChunkIds) {
+      final chunkCoordinates = chunkId.split(',').map(int.parse).toList();
+      final chunkX = chunkCoordinates[0];
+      final chunkY = chunkCoordinates[1];
+
+      if ((chunkX - currentChunk.x).abs() > chunkRange || (chunkY - currentChunk.y).abs() > chunkRange) {
+        chunksToRemove.add(chunkId);
+      }
+    }
+
+    for (var chunkId in chunksToRemove) {
+      _removeComponentsChunk(chunkId);
+      loadedChunkIds.remove(chunkId);
+    }
+
+    _isExecutingDistantChunk = false;
+  }
+
+  void _removeComponentsChunk(String chunkId) {
+    if (loadedChunkComponents.containsKey(chunkId)) {
+      for (var component in loadedChunkComponents[chunkId]!) {
+        component.removeFromParent();
+        _components.remove(component);
+      }
+      loadedChunkComponents.remove(chunkId);
+    }
+  }
+
+  String _getChunkId(int chunkX, int chunkY) {
+    return '$chunkX,$chunkY';
+  }
+
+  String _getLayerChunkId(int layer, String chunkId) {
+    return '$layer-$chunkId';
+  }
+
+  Tile _getTileCopy(Tile tile, double positionX, double positionY) {
+    return Tile(
+      x: positionX,
+      y: positionY,
+      offsetX: tile.offsetX,
+      offsetY: tile.offsetY,
+      width: tile.width,
+      height: tile.height,
+      tileClass: tile.tileClass,
+      properties: tile.properties,
+      sprite: tile.sprite,
+      color: tile.color,
+      animation: tile.animation,
+      collisions: tile.collisions,
+      angle: tile.angle,
+      opacity: tile.opacity,
+      isFlipVertical: tile.isFlipVertical,
+      isFlipHorizontal: tile.isFlipHorizontal,
+    );
+  }
+
+  Vector2 getCurrentChunk(Vector2 position) {
+    final int chunkX = (position.x / (_chunkSizeX * tileSize)).floor();
+    final int chunkY = (position.y / (_chunkSizeY * tileSize)).floor();
+    return Vector2(chunkX.toDouble(), chunkY.toDouble());
+  }
+}

--- a/lib/map/world_map.dart
+++ b/lib/map/world_map.dart
@@ -11,6 +11,7 @@ class WorldMap extends GameMap {
   Vector2 lastCameraWindow = Vector2.zero();
   double lastMinorZoom = 1.0;
   Vector2? lastSizeScreen;
+  bool infinite;
   bool _buildingTiles = false;
   bool _needUpdateRenderedTiles = false;
   Vector2 _mapPosition = Vector2.zero();
@@ -25,6 +26,7 @@ class WorldMap extends GameMap {
   WorldMap(
     List<Layer> layers, {
     double tileSizeToUpdate = 0,
+    this.infinite = false,
   }) : super(
           layers,
           sizeToUpdate: tileSizeToUpdate,
@@ -90,7 +92,7 @@ class WorldMap extends GameMap {
       lastMinorZoom = gameRef.camera.zoom;
       _calculatePositionAndSize();
       for (var layer in layersComponent) {
-        layer.initLayer(size, sizeScreen);
+        layer.initLayer(size, sizeScreen, infiniteMap: infinite);
       }
     }
     if (sizeToUpdate == 0) {


### PR DESCRIPTION
# Description

New Feature for Implementing an Infinite Map using the Tiled Library to manage tiles and map components, allowing the map to expand dynamically as the player moves, creating the illusion of an infinite world.

**Feature Summary:**

**1. Dynamic Chunk Management:**

- The class handles the dynamic loading of map "chunks," which are blocks of tiles and components, based on the player's camera position. This allows the map to expand as needed, ensuring that only visible or nearby chunks are loaded.

**2. Infinite Map Types:**

- The class supports different types of infinite maps (OPEN, VERTICAL, HORIZONTAL), adjusting the chunk loading based on the selected type.

**3. Chunk Loading and Removal:**

- The _loadChunks method is responsible for loading new chunks as the player approaches the edges of the visible map. The _removeDistantChunks method removes chunks that are too far from the player's current position, freeing up resources.

**4. Tile and Component Maintenance:**

- The class maintains a map of the initial tiles and loads new tiles and components for each chunk as needed. The methods _buildLayersChunk and _buildComponentsChunk handle this task.

**5. Optimization and Performance Management:**

- The class uses data structures like maps (Map) and sets (Set) to track loaded chunks and avoid unnecessary reloading, improving performance.

**6. Integration with Bonfire and Tiled:**

- The class integrates directly with Bonfire and Tiled, using the TiledWorldBuilder to construct and manage the map content.

**7. Camera Control and Margins:**

- The class considers margins around the camera to decide when to load or remove chunks, ensuring that the transition between chunks is smooth and imperceptible to the player.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `dart format --output=none --set-exit-if-changed .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.
