### PR TITLE
Fix: oversized and layer order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [next]
+- **BREAKING:** Tiles whose sprite is larger than the map cell (e.g. a 192×256 tree on a 64×64 map) are no longer squished to fit the cell. They are now automatically extracted as `GameDecoration` and rendered at their native size, anchored to the bottom-left of the cell — matching how the Tiled editor previews them. Projects that relied on the previous behaviour (oversized tilesets being forced into the map tile size) will see these tiles render larger than before.
+- Add `type=layered` Tiled layer property. When set, extracted decorations from that layer are attached as children of the `WorldMap` (instead of game-level siblings), so they interleave with regular tile layers following Tiled's natural layer order. Opt-in to avoid breaking maps that rely on the current Y-sort behaviour.
+- Add `priorityOverride` to `GameComponent` to let components pin a fixed render priority instead of using the default Y-sort computation.
+
 # 3.16.1
 - Performance improvements
 

--- a/lib/map/tiled/builder/tiled_world_builder.dart
+++ b/lib/map/tiled/builder/tiled_world_builder.dart
@@ -158,7 +158,11 @@ class TiledWorldBuilder {
               (data.tileClass?.contains(ABOVE_TYPE) ?? false) ||
               layerIsAbove;
           final isDynamic = data.type?.contains(DYNAMIC_ABOVE_TYPE) ?? false;
-          if (tileIsAbove || isDynamic) {
+          final nativeSize = data.sprite?.size;
+          final isOversized = nativeSize != null &&
+              (nativeSize.x > _tileWidthOrigin ||
+                  nativeSize.y > _tileHeightOrigin);
+          if (tileIsAbove || isDynamic || isOversized) {
             _addGameDecorationAbove(
               data,
               count,
@@ -211,15 +215,31 @@ class TiledWorldBuilder {
     double opacity, {
     bool above = false,
   }) {
+    // Native tileset size (may exceed the map's tile size for oversized
+    // decorations like trees). When it does, draw at the native size and
+    // anchor the sprite to the bottom-left of its grid cell, matching how
+    // the Tiled editor renders oversized tiles.
+    final nativeSize = data.sprite?.size;
+    final scaleX =
+        _tileWidthOrigin == 0 ? 1.0 : _tileWidth / _tileWidthOrigin;
+    final scaleY =
+        _tileHeightOrigin == 0 ? 1.0 : _tileHeight / _tileHeightOrigin;
+    final drawW = (nativeSize?.x ?? _tileWidthOrigin) * scaleX;
+    final drawH = (nativeSize?.y ?? _tileHeightOrigin) * scaleY;
+    final cellX = _getX(count, tileLayer.width?.toInt() ?? 1);
+    final cellY = _getY(count, tileLayer.width?.toInt() ?? 1);
+    final position = Vector2(
+      cellX * _tileWidth,
+      (cellY + 1) * _tileHeight - drawH,
+    );
+    final size = Vector2(drawW, drawH);
+
     GameDecoration? comp;
     if (data.animation != null) {
       comp = GameDecorationWithCollision.withAnimation(
         animation: data.animation!.getFutureSpriteAnimation(),
-        position: Vector2(
-          _getX(count, tileLayer.width?.toInt() ?? 1) * _tileWidth,
-          _getY(count, tileLayer.width?.toInt() ?? 1) * _tileHeight,
-        ),
-        size: Vector2(_tileWidth, _tileHeight),
+        position: position,
+        size: size,
         collisions: data.collisions,
         renderAboveComponents: above,
       )
@@ -231,11 +251,8 @@ class TiledWorldBuilder {
       if (data.sprite != null) {
         comp = GameDecorationWithCollision.withSprite(
           sprite: data.sprite!.getFutureSprite(),
-          position: Vector2(
-            _getX(count, tileLayer.width?.toInt() ?? 1) * _tileWidth,
-            _getY(count, tileLayer.width?.toInt() ?? 1) * _tileHeight,
-          ),
-          size: Vector2(_tileWidth, _tileHeight),
+          position: position,
+          size: size,
           collisions: data.collisions,
           renderAboveComponents: above,
         )

--- a/lib/map/tiled/builder/tiled_world_builder.dart
+++ b/lib/map/tiled/builder/tiled_world_builder.dart
@@ -30,6 +30,7 @@ typedef ObjectBuilder = GameComponent Function(
 
 class TiledWorldBuilder {
   static const ABOVE_TYPE = 'above';
+  static const LAYERED_TYPE = 'layered';
   static const DYNAMIC_ABOVE_TYPE = 'dynamicAbove';
   static const _mapOrientationSupported = 'orthogonal';
 
@@ -39,6 +40,7 @@ class TiledWorldBuilder {
   final double sizeToUpdate;
   final List<Layer> _layers = [];
   final List<GameComponent> _components = [];
+  final List<GameComponent> _mapDecorations = [];
   String? _basePath;
   TiledMap? _tiledMap;
   double _tileWidth = 0;
@@ -91,6 +93,7 @@ class TiledWorldBuilder {
           tileSizeToUpdate: sizeToUpdate,
         ),
         components: _components,
+        mapChildren: _mapDecorations,
       ),
     );
   }
@@ -142,13 +145,9 @@ class TiledWorldBuilder {
     final offsetX = _getDoubleByProportion(tileLayer.offsetX);
     final offsetY = _getDoubleByProportion(tileLayer.offsetY);
     final opacity = tileLayer.opacity ?? 1.0;
-    final layerIsAbove = tileLayer.properties
-            ?.where(
-              (element) =>
-                  element.name == 'type' && element.value == ABOVE_TYPE,
-            )
-            .isNotEmpty ??
-        false;
+    final layerIsAbove = _layerHasType(tileLayer, ABOVE_TYPE);
+    final layerIsLayered = _layerHasType(tileLayer, LAYERED_TYPE);
+    final layerIndex = countTileLayer;
     for (final tile in tileLayer.data ?? const <int>[]) {
       if (tile != 0) {
         final data = _getDataTile(tile);
@@ -169,6 +168,8 @@ class TiledWorldBuilder {
               tileLayer,
               opacity,
               above: tileIsAbove,
+              layered: layerIsLayered,
+              layerIndex: layerIndex,
             );
           } else {
             _addTile(data, count, tileLayer, offsetX, offsetY, opacity);
@@ -177,6 +178,14 @@ class TiledWorldBuilder {
       }
       count++;
     }
+  }
+
+  bool _layerHasType(tiled.TileLayer tileLayer, String type) {
+    return tileLayer.properties
+            ?.where((element) =>
+                element.name == 'type' && element.value == type)
+            .isNotEmpty ??
+        false;
   }
 
   void _addTile(
@@ -214,6 +223,8 @@ class TiledWorldBuilder {
     tiled.TileLayer tileLayer,
     double opacity, {
     bool above = false,
+    bool layered = false,
+    int layerIndex = 0,
   }) {
     // Native tileset size (may exceed the map's tile size for oversized
     // decorations like trees). When it does, draw at the native size and
@@ -236,26 +247,41 @@ class TiledWorldBuilder {
 
     GameDecoration? comp;
     if (data.animation != null) {
-      comp = GameDecorationWithCollision.withAnimation(
-        animation: data.animation!.getFutureSpriteAnimation(),
-        position: position,
-        size: size,
-        collisions: data.collisions,
-        renderAboveComponents: above,
-      )
+      comp = (layered
+          ? _LayeredTiledDecoration.withAnimation(
+              fixedPriority: layerIndex,
+              animation: data.animation!.getFutureSpriteAnimation(),
+              position: position,
+              size: size,
+              collisions: data.collisions,
+            )
+          : GameDecorationWithCollision.withAnimation(
+              animation: data.animation!.getFutureSpriteAnimation(),
+              position: position,
+              size: size,
+              collisions: data.collisions,
+              renderAboveComponents: above,
+            ))
         ..angle = data.angle
         ..opacity = opacity
         ..properties = data.properties;
-      _components.add(comp);
     } else {
       if (data.sprite != null) {
-        comp = GameDecorationWithCollision.withSprite(
-          sprite: data.sprite!.getFutureSprite(),
-          position: position,
-          size: size,
-          collisions: data.collisions,
-          renderAboveComponents: above,
-        )
+        comp = (layered
+            ? _LayeredTiledDecoration.withSprite(
+                fixedPriority: layerIndex,
+                sprite: data.sprite!.getFutureSprite(),
+                position: position,
+                size: size,
+                collisions: data.collisions,
+              )
+            : GameDecorationWithCollision.withSprite(
+                sprite: data.sprite!.getFutureSprite(),
+                position: position,
+                size: size,
+                collisions: data.collisions,
+                renderAboveComponents: above,
+              ))
           ..angle = data.angle
           ..properties = data.properties;
       }
@@ -269,7 +295,15 @@ class TiledWorldBuilder {
       comp?.flipVerticallyAroundCenter();
     }
     if (comp != null) {
-      _components.add(comp);
+      if (layered) {
+        // Opt-in via `type=layered`: attach as a child of the WorldMap so
+        // the decoration interleaves with the regular tile layers following
+        // Tiled's layer order. Without this flag the decoration stays at
+        // game level (legacy behaviour) and is Y-sorted above the tile map.
+        _mapDecorations.add(comp);
+      } else {
+        _components.add(comp);
+      }
     }
   }
 
@@ -660,4 +694,31 @@ class TiledWorldBuilder {
       isSolid: true,
     );
   }
+}
+
+/// `GameDecoration` used by [TiledWorldBuilder] for tiles marked with
+/// `type=layered`. Its render priority is fixed to the Tiled layer index so it
+/// interleaves with the tile layers inside the `WorldMap` subtree instead of
+/// being Y-sorted against the game-level components.
+class _LayeredTiledDecoration extends GameDecorationWithCollision {
+  _LayeredTiledDecoration.withSprite({
+    required this.fixedPriority,
+    required super.sprite,
+    required super.position,
+    required super.size,
+    super.collisions,
+  }) : super.withSprite();
+
+  _LayeredTiledDecoration.withAnimation({
+    required this.fixedPriority,
+    required super.animation,
+    required super.position,
+    required super.size,
+    super.collisions,
+  }) : super.withAnimation();
+
+  final int fixedPriority;
+
+  @override
+  int get priority => fixedPriority;
 }

--- a/lib/map/tiled/model/tiled_world_data.dart
+++ b/lib/map/tiled/model/tiled_world_data.dart
@@ -4,5 +4,14 @@ class WorldBuildData {
   final WorldMap map;
   final List<GameComponent>? components;
 
-  WorldBuildData({required this.map, this.components});
+  /// Decorations that must render as children of the tile map (e.g. oversized
+  /// tiles from Tiled whose stacking must follow the layer order instead of
+  /// the dynamic Y-sort used by game-level components).
+  final List<GameComponent>? mapChildren;
+
+  WorldBuildData({
+    required this.map,
+    this.components,
+    this.mapChildren,
+  });
 }

--- a/lib/map/tiled/world_map_by_tiled.dart
+++ b/lib/map/tiled/world_map_by_tiled.dart
@@ -27,6 +27,13 @@ class WorldMapByTiled extends WorldMap {
     final map = await _builder.build();
     layers = map.map.layers;
     gameRef.addAll(map.components ?? []);
+    // `mapChildren` are decorations that must live inside the WorldMap
+    // subtree (not as game-level siblings) so their priority is compared
+    // against the tile layers and they can interleave following Tiled's
+    // layer order. See `type=layered` handling in TiledWorldBuilder.
+    for (final child in map.mapChildren ?? const <GameComponent>[]) {
+      add(child);
+    }
     return super.onLoad();
   }
 }


### PR DESCRIPTION
**Fixes #600**

Two related fixes in TiledWorldBuilder: oversized tiles are now rendered at their
native size, and a new opt-in type=layered layer property lets extracted decorations
 respect Tiled's layer order.

https://github.com/juarezfranco/issues_examples/blob/main/bonfire_issue_600/example.
gif

**Fix 1 - Oversized tiles are squished**

**Problem**

Tiles whose sprite is larger than the map's tile size (e.g. a 192×256 tree on a
64×64 map) were being rendered shrunk to fit a single grid cell, instead of
overflowing their cell and anchoring to the bottom-left the way Tiled previews them.

In _addTileLayer, any tile that wasn't marked type=above / type=dynamicAbove went
through the normal tile path, which always builds the tile at the map's cell size.
There was no detection for tiles whose native sprite size exceeds the cell.

**Change**

Detect oversized tiles automatically and route them through the existing
GameDecoration extraction path, rendered at their native size with a bottom-left
anchor — matching how Tiled previews them. No config required from the map author;
any tile whose sprite exceeds the cell is handled automatically.

**Fix 2 - Layer order is lost after extraction (type=layered)**

Problem (surfaced by Fix 1)

Once an oversized tile becomes a GameDecoration, it is added via
gameRef.addAll(...), which makes it a sibling of the WorldMap, not a child:

BonfireGame
├── WorldMap            ← holds all tile layers internally
│   ├── tile layer 0
│   ├── tile layer 1
│   └── tile layer 2
└── GameDecoration      ← sibling of the entire map

Flame's priority system only orders siblings within the same parent. A game-level
decoration can be above or below the whole WorldMap, but it can never sit between
two tile layers, they live in a different subtree.

Concretely: a water tile on layer 1 and a splash animation on layer 2 would both be
dragged above the terrain on layer 3, because the splash was promoted to game level
and Y-sorted above the tile map as a block.

This wasn't visible before Fix 1 because oversized tiles used to stay squished
inside their tile layer - wrong size, but correct layer order. Fixing the size broke
 the ordering, so both had to be addressed together.

**Change - opt-in type=layered layer property**

New Tiled layer property: type=layered.

When a tile layer has this property, oversized (or otherwise extracted) decorations
from that layer are attached as children of the WorldMap instead of siblings, with
their priority pinned to the layer index. They live in the same subtree as the tile
layers, so priority comparisons become meaningful and the decorations interleave
with the regular tile layers following Tiled's natural layer order.

Why opt-in instead of automatic

Making every oversized tile layered by default would be a breaking change: projects
that rely on the current behaviour (decorations Y-sorted above the tile map, player
passing behind them) would suddenly see them pinned to layer order and the player
rendered on top. type=layered is opt-in on the layer, so existing maps keep working.

Compatibility

- Maps without oversized tiles: no behavioural change.
- Maps with oversized tiles: now render at native size instead of squished.
- type=layered is opt-in; no existing map is affected unless the author adds it.
- No public API breaks.

Repro / validation

Minimal repro with a before/after side-by-side:
https://github.com/juarezfranco/issues_examples/tree/main/bonfire_issue_600

- bug/ — uses bonfire: ^3.16.1 (pub), reproduces the squish and layer-order issues.
- fix/ — same project pointing at this branch, renders correctly.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [ ] I ran `dart format --output=none --set-exit-if-changed .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
```
Oversized Tiled tiles (sprite larger than the map cell) are no longer squished to
fit the cell. They now render at their native size, anchored to the bottom-left of
the cell, matching how the Tiled editor previews them. Projects that depended on the
 previous squish behaviour will see these tiles render larger than before.
```
- [ ] No, this is *not* a breaking change.
